### PR TITLE
Removed fixuid from the radar object detection dockerfile

### DIFF
--- a/docker/perception/radar_object_detection.Dockerfile
+++ b/docker/perception/radar_object_detection.Dockerfile
@@ -1,24 +1,16 @@
+# ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Add a docker user so that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
-    chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN sudo chsh -s /bin/bash
+ENV SHELL=/bin/bash
+
+# ================= Repositories ===================
+FROM base as repo
 
 RUN mkdir -p ~/ament_ws/src
 WORKDIR /home/docker/ament_ws/src


### PR DESCRIPTION
In PR https://github.com/WATonomous/wato_monorepo/pull/21, it was noticed that the radar_object_detection.dockerfile was not fully up to update. This PR is to update the dockerfile.