### PR TITLE
Avoiding gpu mount in CI

### DIFF
--- a/.github/templates/test/action.yml
+++ b/.github/templates/test/action.yml
@@ -1,14 +1,11 @@
 name: Docker test
 
 inputs:
-  module:
-    description: "the module to be enabled"
+  image:
+    description: "monorepo image to test"
     required: true
-  service:
-    description: "the service being tested"
-    required: true
-  source_branch:
-    description: "the source branch"
+  tag:
+    description: "monorepo image tag to test"
     required: true
 
 runs: 
@@ -17,6 +14,5 @@ runs:
     - run: ${{ github.action_path }}/test_image.sh
       shell: bash
       env:
-        TAG: build_${{ inputs.source_branch }}
-        ACTIVE_MODULES: ${{ inputs.module }}
-        SERVICE: ${{ inputs.service }}
+        IMAGE: ${{ inputs.image }}
+        TAG: ${{ inputs.tag }}

--- a/.github/templates/test/test_image.sh
+++ b/.github/templates/test/test_image.sh
@@ -3,15 +3,3 @@ set -e
 
 docker pull -q $IMAGE:$TAG
 docker run $IMAGE:$TAG /bin/bash -c "source /home/bolty/ament_ws/install/setup.bash; colcon test; colcon test-result --verbose"
-
-# echo "Running $SERVICE tests..."
-# CONTAINER_NAME="$SERVICE-github-actions"
-
-# # Run docker-compose service with watod in detached mode and prevent early exit
-# bash watod -dev pull "$SERVICE"
-# bash watod -dev run -d --name "$CONTAINER_NAME" "$SERVICE" tail -f /dev/null
-
-# # Run tests for ros2 packages, on failure script will exit with error message
-# docker exec "$CONTAINER_NAME" /bin/bash -c "source /home/bolty/ament_ws/install/setup.bash; colcon test; colcon test-result --verbose"
-
-# bash watod -dev down

--- a/.github/templates/test/test_image.sh
+++ b/.github/templates/test/test_image.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 set -e
 
-echo "Running $SERVICE tests..."
-CONTAINER_NAME="$SERVICE-github-actions"
+docker pull -q $IMAGE:$TAG
+docker run $IMAGE:$TAG /bin/bash -c "source /home/bolty/ament_ws/install/setup.bash; colcon test; colcon test-result --verbose"
 
-# Run docker-compose service in detached mode and prevent early exit
-bash watod -dev pull "$SERVICE"
-bash watod -dev run -d --name "$CONTAINER_NAME" "$SERVICE" tail -f /dev/null
+# echo "Running $SERVICE tests..."
+# CONTAINER_NAME="$SERVICE-github-actions"
 
-# Run tests for ros2 packages, on failure script will exit with error message
-docker exec "$CONTAINER_NAME" /bin/bash -c "source /home/bolty/ament_ws/install/setup.bash; colcon test; colcon test-result --verbose"
+# # Run docker-compose service with watod in detached mode and prevent early exit
+# bash watod -dev pull "$SERVICE"
+# bash watod -dev run -d --name "$CONTAINER_NAME" "$SERVICE" tail -f /dev/null
 
-bash watod -dev down
+# # Run tests for ros2 packages, on failure script will exit with error message
+# docker exec "$CONTAINER_NAME" /bin/bash -c "source /home/bolty/ament_ws/install/setup.bash; colcon test; colcon test-result --verbose"
+
+# bash watod -dev down

--- a/.github/workflows/build_and_unitest.yml
+++ b/.github/workflows/build_and_unitest.yml
@@ -131,6 +131,5 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           BUILDKIT_INLINE_CACHE: 1
         with:
-          module: ${{ matrix.module }}
-          service: ${{ matrix.service }}
-          source_branch: ${{ env.SOURCE_BRANCH }}
+          image: ${{ steps.construct-registry-url.outputs.url }}
+          tag: build_${{ env.SOURCE_BRANCH }}

--- a/src/samples/cpp/aggregator/test/aggregator_test.cpp
+++ b/src/samples/cpp/aggregator/test/aggregator_test.cpp
@@ -10,7 +10,7 @@ TEST(AggregatorTest, RawDivisionByZero)
 {
   samples::AggregatorCore aggregator(0);
   auto msg = std::make_shared<sample_msgs::msg::Unfiltered>();
-  msg->timestamp = 0;
+  msg->timestamp = 2;
 
   aggregator.add_raw_msg(msg);
   EXPECT_DOUBLE_EQ(0.0, aggregator.raw_frequency());

--- a/src/samples/cpp/aggregator/test/aggregator_test.cpp
+++ b/src/samples/cpp/aggregator/test/aggregator_test.cpp
@@ -10,7 +10,7 @@ TEST(AggregatorTest, RawDivisionByZero)
 {
   samples::AggregatorCore aggregator(0);
   auto msg = std::make_shared<sample_msgs::msg::Unfiltered>();
-  msg->timestamp = 2;
+  msg->timestamp = 0;
 
   aggregator.add_raw_msg(msg);
   EXPECT_DOUBLE_EQ(0.0, aggregator.raw_frequency());


### PR DESCRIPTION
Avoids 
```
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              count: 1
              capabilities: [ gpu ]
```
in ci because runners don't have gpus