### PR TITLE
Upgrade to medium size model

### DIFF
--- a/modules/docker-compose.perception.yaml
+++ b/modules/docker-compose.perception.yaml
@@ -30,7 +30,7 @@ services:
               capabilities: [ gpu ]
     command: /bin/bash -c "ros2 launch camera_object_detection eve_launch.py"
     volumes:
-      - /mnt/wato-drive2/perception_models/yolov8s.pt:/perception_models/yolov8s.pt
+      - /mnt/wato-drive2/perception_models/yolov8m.pt:/perception_models/yolov8m.pt
 
   lidar_object_detection:
     build:

--- a/src/perception/camera_object_detection/camera_object_detection/yolov8_detection.py
+++ b/src/perception/camera_object_detection/camera_object_detection/yolov8_detection.py
@@ -34,7 +34,7 @@ class CameraDetectionNode(Node):
         self.declare_parameter("camera_topic", "/camera/right/image_color")
         self.declare_parameter("publish_vis_topic", "/annotated_img")
         self.declare_parameter("publish_detection_topic", "/detections")
-        self.declare_parameter("model_path", "/perception_models/yolov8s.pt")
+        self.declare_parameter("model_path", "/perception_models/yolov8m.pt")
         self.declare_parameter("image_size", 480)
         self.declare_parameter("compressed", False)
 

--- a/src/perception/camera_object_detection/camera_object_detection/yolov8_detection.py
+++ b/src/perception/camera_object_detection/camera_object_detection/yolov8_detection.py
@@ -35,7 +35,7 @@ class CameraDetectionNode(Node):
         self.declare_parameter("publish_vis_topic", "/annotated_img")
         self.declare_parameter("publish_detection_topic", "/detections")
         self.declare_parameter("model_path", "/perception_models/yolov8m.pt")
-        self.declare_parameter("image_size", 480)
+        self.declare_parameter("image_size", 1024)
         self.declare_parameter("compressed", False)
 
         self.camera_topic = self.get_parameter("camera_topic").value

--- a/src/perception/camera_object_detection/config/deepracer_config.yaml
+++ b/src/perception/camera_object_detection/config/deepracer_config.yaml
@@ -4,4 +4,4 @@ camera_object_detection_node:
     publish_vis_topic: /annotated_img
     publish_obstacle_topic: /obstacles
     model_path: /perception_models/yolov8m.pt
-    image_size: 480
+    image_size: 1024

--- a/src/perception/camera_object_detection/config/deepracer_config.yaml
+++ b/src/perception/camera_object_detection/config/deepracer_config.yaml
@@ -3,5 +3,5 @@ camera_object_detection_node:
     camera_topic: /camera_pkg/display_mjpeg
     publish_vis_topic: /annotated_img
     publish_obstacle_topic: /obstacles
-    model_path: /perception_models/yolov8s.pt
+    model_path: /perception_models/yolov8m.pt
     image_size: 480

--- a/src/perception/camera_object_detection/config/eve_config.yaml
+++ b/src/perception/camera_object_detection/config/eve_config.yaml
@@ -3,7 +3,7 @@ left_camera_object_detection_node:
     camera_topic: /camera/left/image_color
     publish_vis_topic: /camera/left/annotated_img
     publish_detection_topic: /camera/left/detections
-    model_path: /perception_models/yolov8s.pt
+    model_path: /perception_models/yolov8m.pt
     image_size: 480
 
 center_camera_object_detection_node:
@@ -11,7 +11,7 @@ center_camera_object_detection_node:
     camera_topic: /camera/center/image_color
     publish_vis_topic: /camera/center/annotated_img
     publish_detection_topic: /camera/center/detections
-    model_path: /perception_models/yolov8s.pt
+    model_path: /perception_models/yolov8m.pt
     image_size: 480
 
 right_camera_object_detection_node:
@@ -19,5 +19,5 @@ right_camera_object_detection_node:
     camera_topic: /camera/right/image_color
     publish_vis_topic: /camera/right/annotated_img
     publish_detection_topic: /camera/right/detections
-    model_path: /perception_models/yolov8s.pt
+    model_path: /perception_models/yolov8m.pt
     image_size: 480

--- a/src/perception/camera_object_detection/config/eve_config.yaml
+++ b/src/perception/camera_object_detection/config/eve_config.yaml
@@ -4,7 +4,7 @@ left_camera_object_detection_node:
     publish_vis_topic: /camera/left/annotated_img
     publish_detection_topic: /camera/left/detections
     model_path: /perception_models/yolov8m.pt
-    image_size: 480
+    image_size: 1024
 
 center_camera_object_detection_node:
   ros__parameters:
@@ -12,7 +12,7 @@ center_camera_object_detection_node:
     publish_vis_topic: /camera/center/annotated_img
     publish_detection_topic: /camera/center/detections
     model_path: /perception_models/yolov8m.pt
-    image_size: 480
+    image_size: 1024
 
 right_camera_object_detection_node:
   ros__parameters:
@@ -20,4 +20,4 @@ right_camera_object_detection_node:
     publish_vis_topic: /camera/right/annotated_img
     publish_detection_topic: /camera/right/detections
     model_path: /perception_models/yolov8m.pt
-    image_size: 480
+    image_size: 1024

--- a/src/perception/camera_object_detection/config/nuscenes_config.yaml
+++ b/src/perception/camera_object_detection/config/nuscenes_config.yaml
@@ -3,6 +3,6 @@ camera_object_detection_node:
     camera_topic: /CAM_FRONT/image_rect_compressed
     publish_vis_topic: /annotated_img
     publish_obstacle_topic: /obstacles
-    model_path: /perception_models/yolov8s.pt
+    model_path: /perception_models/yolov8m.pt
     image_size: 640
     compressed: true


### PR DESCRIPTION
![image](https://github.com/WATonomous/wato_monorepo/assets/43485866/dafcd100-a906-4e42-b27b-04c321262a66)

Better accuracy. We can either use YOLOv8m or YOLOv8l (YOLOv8x is overkill). Settling for medium as it seems a good compromise.

Also increased default model resolution