### PR TITLE
Depth estimation perf

### DIFF
--- a/src/perception/depth_estimation/config/config.yaml
+++ b/src/perception/depth_estimation/config/config.yaml
@@ -6,3 +6,7 @@ depth_estimation_node:
     publish_depth_pcl_topic: /camera/right/depth_pcl
     small_model_path: /perception_models/depth_estimation_v2_small.pth
     large_model_path: /perception_models/depth_estimation_v2_large.pth
+    focal_length_x: 470.4
+    focal_length_y: 470.4
+    min_depth_offset: 0    # const distance to add to depth inference (meters)
+    max_depth_cuttoff: 79     # pre-offset distance to ignore for sky (meters)

--- a/src/perception/depth_estimation/depth_estimation/depth_estimation.py
+++ b/src/perception/depth_estimation/depth_estimation/depth_estimation.py
@@ -87,36 +87,7 @@ class DepthAnything(Node):
         )
 
         # Create the output directory if it doesn't exist
-        os.makedirs(self.outdir, exist_ok=True)
-
-        # test throughput by spamming publishes
-        # for i in range(20):
-        #     self.test_image_once()
-
-    def test_image_once(self):
-        self.test_image_publisher = self.create_publisher(
-            CompressedImage,
-            self.camera_topic,
-            100
-        )
-        test_img = "/home/bolty/ament_ws/src/Depth-Anything-V2/assets/examples/demo01.jpg"
-        cv_image = cv2.imread(test_img)
-        cv_image = cv2.resize(cv_image, (1080, 720))
-        if cv_image is None:
-            self.get_logger().error(f"no image at {test_img}")
-            return
-
-        # cv2 to ros msg
-        try:
-            compressed_msg = CompressedImage()
-            params = [cv2.IMWRITE_JPEG_QUALITY, 80]
-            _, encoded_image = cv2.imencode('.jpg', cv_image, params)
-            compressed_msg.data = encoded_image.tobytes()
-
-            self.get_logger().info("publishing test image")
-            self.test_image_publisher.publish(compressed_msg)
-        except Exception as e:
-            self.get_logger().error(f"error converting image: {e}")
+        # os.makedirs(self.outdir, exist_ok=True)
 
     def image_callback(self, msg):
         t_start = time.time()

--- a/src/perception/depth_estimation/depth_estimation/depth_estimation.py
+++ b/src/perception/depth_estimation/depth_estimation/depth_estimation.py
@@ -71,7 +71,7 @@ class DepthAnything(Node):
             CompressedImage,
             self.camera_topic,
             self.image_callback,
-            60
+            10
         )
 
         self.depth_img_publisher = self.create_publisher(

--- a/src/perception/depth_estimation/requirements.txt
+++ b/src/perception/depth_estimation/requirements.txt
@@ -1,3 +1,12 @@
+# version 1.x required by ros
+numpy==1.24.4
+open3d
+
+# DepthAnything2 modules
+transformers
+gradio_imageslider
+gradio==4.29.0
+matplotlib
 opencv-python
 torch
-open3d
+torchvision


### PR DESCRIPTION
End to end performance optimization for image inference and point cloud serialization (3fps -> 20fps):
 - resize image input to 518x518 for depth estimation (recommended), then interpolate back to HD
 - refactor object creation in during serialization to reduce memory accesses
 - remove unused point cloud information (ie. color)
 - also refactor docker image to cache DepthAnything pip dependencies earlier for faster rebuild times

Suggest to be merged before integrating depth inference with TensorRT by @conjeevaram 