### PR TITLE
Add WATONOMOUS_INSTALL environment variable

### DIFF
--- a/docker/base/inject_wato_base.Dockerfile
+++ b/docker/base/inject_wato_base.Dockerfile
@@ -14,6 +14,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 ENV USER="bolty"
 ENV AMENT_WS=/home/${USER}/ament_ws
+ENV WATONOMOUS_INSTALL=/opt/watonomous/
 
 # User Setup
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Looks like the `WATONOMOUS_INSTALL` env variable is not being set in the `inject_wato_base` Dockerfile. This must have been working before so I'm not sure in which commit this may have been removed. This change sets it to `WATONOMOUS_INSTALL=/opt/watonomous/`

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
