### PR TITLE
Fix grep usage in dockerfiles

### DIFF
--- a/docker/action/action.Dockerfile
+++ b/docker/action/action.Dockerfile
@@ -16,7 +16,7 @@ COPY src/wato_msgs/simulation/mit_contributing.txt ${AMENT_WS}/src/ros-carla-msg
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/infrastructure/infrastructure.Dockerfile
+++ b/docker/infrastructure/infrastructure.Dockerfile
@@ -16,7 +16,7 @@ COPY src/wato_msgs/simulation/mit_contributing.txt ${AMENT_WS}/src/ros-carla-msg
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/interfacing/interfacing.Dockerfile
+++ b/docker/interfacing/interfacing.Dockerfile
@@ -16,7 +16,7 @@ COPY src/wato_msgs/simulation/mit_contributing.txt ${AMENT_WS}/src/ros-carla-msg
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/perception/camera_object_detection/camera_object_detection.Dockerfile
+++ b/docker/perception/camera_object_detection/camera_object_detection.Dockerfile
@@ -13,7 +13,7 @@ COPY src/wato_msgs/perception_msgs/camera_object_detection_msgs  camera_object_d
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-      | grep 'apt-get install' \
+      | (grep 'apt-get install' || true) \
       | awk '{print $3}' \
       | sort  > /tmp/colcon_install_list
 

--- a/docker/perception/depth_estimation/depth_estimation.Dockerfile
+++ b/docker/perception/depth_estimation/depth_estimation.Dockerfile
@@ -20,7 +20,7 @@ COPY src/perception/depth_estimation depth_estimation
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-      | grep 'apt-get install' \
+      | (grep 'apt-get install' || true) \
       | awk '{print $3}' \
       | sort > /tmp/colcon_install_list
 

--- a/docker/perception/lane_detection/lane_detection.Dockerfile
+++ b/docker/perception/lane_detection/lane_detection.Dockerfile
@@ -14,7 +14,7 @@ COPY src/wato_msgs/perception_msgs/lane_detection_msgs            lane_detection
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-      | grep 'apt-get install' \
+      | (grep 'apt-get install' || true) \
       | awk '{print $3}' \
       | sort > /tmp/colcon_install_list
 

--- a/docker/perception/lidar_object_detection/lidar_object_detection.Dockerfile
+++ b/docker/perception/lidar_object_detection/lidar_object_detection.Dockerfile
@@ -12,7 +12,7 @@ COPY src/perception/lidar_object_detection                  lidar_object_detecti
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-      | grep 'apt-get install' \
+      | (grep 'apt-get install' || true) \
       | awk '{print $3}' \
       | sort > /tmp/colcon_install_list
 

--- a/docker/perception/perception.Dockerfile
+++ b/docker/perception/perception.Dockerfile
@@ -16,7 +16,7 @@ COPY src/wato_msgs/simulation/mit_contributing.txt ${AMENT_WS}/src/ros-carla-msg
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/perception/tracking/tracking.Dockerfile
+++ b/docker/perception/tracking/tracking.Dockerfile
@@ -14,7 +14,7 @@ COPY src/wato_msgs/perception_msgs/camera_object_detection_msgs          camera_
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-      | grep 'apt-get install' \
+      | (grep 'apt-get install' || true) \
       | awk '{print $3}' \
       | sort > /tmp/colcon_install_list
 

--- a/docker/simulation/carla_ros_bridge/carla_ros_bridge.Dockerfile
+++ b/docker/simulation/carla_ros_bridge/carla_ros_bridge.Dockerfile
@@ -21,7 +21,7 @@ COPY src/wato_msgs/simulation ros_msgs
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && rosdep update --rosdistro foxy && \
     rosdep install --from-paths . -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort > /tmp/colcon_install_list
 

--- a/docker/simulation/carla_sample_node/carla_sample_node.Dockerfile
+++ b/docker/simulation/carla_sample_node/carla_sample_node.Dockerfile
@@ -21,7 +21,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # TODO (wato) pipefail is failing here
 RUN set +o pipefail && apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/world_modeling/world_modeling.Dockerfile
+++ b/docker/world_modeling/world_modeling.Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -qq update && \
     rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort > /tmp/colcon_install_list && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
This particular command (used in all the dockerfiles)
```
grep 'apt-get install'
```
is not robust. When there are no matches `grep` gives return code 1, **not** 0 which causes the image to stop building. This particular case arises when rosdep finds no dependencies to install. I am not sure why we are encountering this case all of a sudden after rebuilding the base images.  The proposed change is a kind of "hacky" fix to make sure grep always returns exit code 0:
```
(grep 'apt-get install' || true)
```

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
