### PR TITLE
Hot Fix Bag recorder

### DIFF
--- a/watod_scripts/watod-bag.sh
+++ b/watod_scripts/watod-bag.sh
@@ -100,7 +100,7 @@ fi
 cleanup_bag() {
   echo ""
   echo "Stopping recording..."
-  docker stop watod_bag_recorder 2>/dev/null || true
+  docker stop watod_bag_recorder || true
   echo "Recording stopped"
   exit 0
 }
@@ -108,7 +108,7 @@ cleanup_bag() {
 trap cleanup_bag SIGINT SIGTERM
 
 docker run --rm -t \
-  --network host \
+  --network watod_watonomous_default \
   --name watod_bag_recorder \
   -v "$BAG_DIRECTORY:/bags" \
   -w /bags \


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Bag recorder was stopping prematurely. To counteract this, a trap was added to explicitly handle SIGTERM and SIGINT to safely close the bag recorder (limiting the chances of file corruption). Also the network of the bad recorder had to be the same as the network of the other containers.

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

