### PR TITLE
[BUG] Dockerfile messing with permissions in devcontainer for watcloud

### DIFF
--- a/docker/template.Dockerfile
+++ b/docker/template.Dockerfile
@@ -68,6 +68,7 @@ FROM build AS deploy
 # Source Cleanup, Security Setup, and Workspace Setup
 RUN rm -rf "${AMENT_WS:?}"/* && \
     chown -R "${USER}":"${USER}" "${AMENT_WS}"
+USER ${USER}
 
 ################################ Develop ################################
 FROM rosdep_install AS develop


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->

When building and running devcontainer on watcloud, you would not have permissions to edit any of the content that was mounted on to the devcontainer. But you had sudo rights, so you can pass the ownership to the user (bolty) that was created for the devcontainer, but that then lead the user BACK ON THE HOST not have any permissions to edit any of the files that was mounted by the devcontainer. Essentially, your files are not yours anymore and are locked because some user owns the code from a devcontainer. 

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

You will see weird stuff like this:

```bah
rm: cannot remove 'wato_monorepo_old2/src/world_modeling/occupancy/launch/occupancy.launch.py': Permission denied
```

Supposed to be: 

```
drwxr-xr-x  13 jstephhuang jstephhuang   20 Jan 25 00:01 wato_monorepo
```

but ends up being:

```bash
drwxr-xr-x  13    32279796    32279796   20 Jan 25 00:01 wato_monorepo
```

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->

IMPORTANT: this is a workaround!

It works on dev now, you can edit both on the devcontainer and the host without any permissions issue. However, before in the devcontainer the user would be:

```bash
bolty@trpro-slurm2:~/ament_ws$ 
```

now it is just back to what it was before:
```bash
root@trpro-slurm1:/home/bolty/ament_ws#
```