### PR TITLE
[FIX] Fixed Dockerfile error not building when trying to create the user in the devcontainer

### DIFF
--- a/docker/template.Dockerfile
+++ b/docker/template.Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update && \
 # Set user in container to developer's user
 # hadolint ignore=SC2086
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN existing_user=$(getent passwd ${USER_UID} | cut -d: -f1) \
+RUN existing_user=$(getent passwd ${USER_UID} | cut -d: -f1 || true) \
     && if [ -n "$existing_user" ]; then userdel -r "$existing_user" 2>/dev/null || true; fi \
     && if ! getent group ${USER_GID} >/dev/null; then groupadd --gid ${USER_GID} ${USERNAME}; fi \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m $USERNAME --shell /bin/bash \


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
There was build error for the devcontainers when creating the the user when runnning this line: 
```
RUN existing_user=$(getent passwd 1621 | cut -d: -f1) 
```

Added `|| true` after -f1. Fixed the build errors and devcontainer uses the user on the host.
### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [ ] My code builds and runs locally without warnings
- [ ] I added/updated tests if needed
- [ ] I updated documentation / comments
- [ ] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs
Fixes #123
Depends on #456

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
