### PR TITLE
Fix SLURM docker networking issue

### DIFF
--- a/modules/docker-compose.yaml
+++ b/modules/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
     ulimits:
       memlock: -1
     ipc: host
-    network_mode: service:network_namespace 
+    network_mode: service:network_namespace
     pull_policy: never
     build:
       context: ..
@@ -150,7 +150,7 @@ services:
     ulimits:
       memlock: -1
     ipc: host
-    network_mode: service:network_namespace 
+    network_mode: service:network_namespace
     build:
       context: ..
       dockerfile: docker/template.Dockerfile
@@ -203,7 +203,7 @@ services:
     ulimits:
       memlock: -1
     ipc: host
-    network_mode: service:network_namespace 
+    network_mode: service:network_namespace
     build:
       context: ..
       dockerfile: docker/template.Dockerfile
@@ -254,7 +254,7 @@ services:
     ulimits:
       memlock: -1
     ipc: host
-    network_mode: service:network_namespace 
+    network_mode: service:network_namespace
     build:
       context: ..
       dockerfile: docker/template.Dockerfile
@@ -335,7 +335,7 @@ services:
     ulimits:
       memlock: -1
     ipc: host
-    network_mode: service:network_namespace 
+    network_mode: service:network_namespace
     build:
       context: ..
       dockerfile: docker/template.Dockerfile

--- a/watod_scripts/watod-setup-env.sh
+++ b/watod_scripts/watod-setup-env.sh
@@ -103,7 +103,7 @@ ZENOH_SESSION_CONFIG_URI=${ZENOH_SESSION_CONFIG_URI:-"/opt/watonomous/rmw_zenoh_
 # Docker socket path (needed for log viewer)
 # DOCKER_HOST should be automaticall set in any WATCloud SLURM session
 DOCKER_HOST=${DOCKER_HOST:-unix:///var/run/docker.sock}
-DOCKER_SOCKET_PATH=${DOCKER_HOST#unix://} # strip the "unix://" prefix to get path 
+DOCKER_SOCKET_PATH=${DOCKER_HOST#unix://} # strip the "unix://" prefix to get path
 
 ################################  Image names  #######################################
 # NOTE: ALL IMAGE NAMES MUST BE IN THE FORMAT <COMPOSE_FILE>_<SERVICE>

--- a/watod_scripts/watod-test.sh
+++ b/watod_scripts/watod-test.sh
@@ -70,7 +70,7 @@ TEST_PRE_PROFILES=("${PRE_PROFILES[@]}")
 TEST_ROS_DOMAIN_ID=${TEST_ROS_DOMAIN_ID:-99}
 
 # Services to skip (non-ROS services that don't have colcon tests)
-SKIP_SERVICES=("log_viewer", "network_namespace")
+SKIP_SERVICES=("log_viewer"  "network_namespace")
 
 # Track test results
 declare -a TESTED_SERVICES=()


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Problems:
1. Networking Issue:
   - Using `network_mode: host` on the services was breaking on the rootless setup in the WATCloud cluster
   - Specifically, with rootless docker the ports being listened on inside the container seem to be hidden from the host itself. 
2. Docker daemon socket path:
  - For the log viewer it uses the docker python sdk and connects to the docker daemon with the socket path
  - With root-ful docker the socket path is something like `/var/run/docker.sock`
  - On the WATCloud with rootless docker the path is `/tmp/run/docker.sock`
  - This means the hostPath being used in the volume for the log_viewer service is wrong

Fixes:
1.  Networking Fix:
   - Remove `network_mode: host` from services
   - Create a busybox service that's super lightweight that acts as the namespace
   - Use `network_mode: service:namespace_service` to basically inject all other containers into that container's namespace
      - This results in all of the nodes/programs residing in the same namespace, so `localhost` is common to all of them
      - Ex. The carla ros bridge can connect to the carla sim with `localhost:<PORT>` rather than having to use the namespace (which is usually the container name) like `<container_name>:<PORT>`
      - Also from my brief testing, it appears for node discovery zenoh needs everything to be under the same namespace
   - Make all services depend (hard requirement) on the busybox service
2. Docker daemon socket path fix:
   - In WATCloud SLURM session a env variable is available called `$DOCKER_HOST` that has the URL for the unix socket (ex. `unix:///tmp/run/docker.sock`
   - In `watod-setup-env.sh` we get this env var value (also supplying a default so that it still works in root-ful docker) and the extract the socket path and expose that as the env var `DOCKER_SOCKET_PATH`
   - This is then used in the compose file as the hostPath for the volume in the log_viewer service



### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
- For the URLs displayed (for foxglove, log viewer and pygam HUD), when in SLURM session and forwarding the ports you should use `localhost` and not the ip address specified ... I'm not sure where that should be mentioned so that people are aware of this
- Also, unrelated, but I had to rebuild the images ... I think the ones on the registry are outdated. 
