### PR TITLE
Fix passing extra compose args

### DIFF
--- a/watod_scripts/watod-compose.sh
+++ b/watod_scripts/watod-compose.sh
@@ -132,7 +132,7 @@ done
 # If build, run PRE-BUILD stage (source and dependency stages)
 if [[ "${COMPOSE_CMD[0]}" == "build" && ${#PRE_PROFILES[@]} -gt 0 ]]; then
   echo "RUNNING PRE-BUILD"
-  run_docker_compose "${PRE_COMPOSE_FILES[@]}" "${PRE_PROFILE_FLAGS[@]}" build
+  run_docker_compose "${PRE_COMPOSE_FILES[@]}" "${PRE_PROFILE_FLAGS[@]}" build "${EXTRA_COMPOSE_ARGS[@]}"
 
   # In CI, push PRE-BUILD images to registry
   if [[ -n ${CI:-} || -n ${GITHUB_ACTIONS:-} ]]; then


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Extra compose args like no cache were not being passed into the docker compose command from watod. This fixes that.

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section
