### PR TITLE
Fix busybox hanging

### DIFF
--- a/modules/docker-compose.yaml
+++ b/modules/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
 #################### NETWORK NAMESPACE SERVICE ####################
   network_namespace:
     image: busybox:latest
+    init: true
     container_name: watod_network_namespace
     command: sleep infinity
     restart: unless-stopped


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Busybox hanging after `watod down`. Change adds `init: true` so that the container gets shut down.

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [.] My code builds and runs locally without warnings
- [.] I added/updated tests if needed
- [.] I updated documentation / comments
- [.] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
