### PR TITLE
Ways, Conflicting Integration for World Model

### DIFF
--- a/src/simulation/carla_ros_bridge/carla_perception/carla_perception/lidar_publisher_node.py
+++ b/src/simulation/carla_ros_bridge/carla_perception/carla_perception/lidar_publisher_node.py
@@ -472,16 +472,16 @@ class LidarPublisherNode(LifecycleNode):
             )
 
             t = tf.transform.translation
-            x, y, z = t.x, t.y, t.z
-
             q = tf.transform.rotation
             roll, pitch, yaw = quaternion_to_euler(q.x, q.y, q.z, q.w)
 
+            # Convert ROS (right-handed, FLU) to CARLA (left-handed, FRU):
+            # Y axis is flipped, so negate y, pitch, and yaw
             return carla.Transform(
-                carla.Location(x=x, y=y, z=z),
+                carla.Location(x=t.x, y=-t.y, z=t.z),
                 carla.Rotation(
-                    pitch=math.degrees(pitch),
-                    yaw=math.degrees(yaw),
+                    pitch=-math.degrees(pitch),
+                    yaw=-math.degrees(yaw),
                     roll=math.degrees(roll),
                 ),
             )

--- a/src/world_modeling/lanelet_msgs/CMakeLists.txt
+++ b/src/world_modeling/lanelet_msgs/CMakeLists.txt
@@ -26,7 +26,8 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrafficLightInfo.msg"
   "msg/StopLineInfo.msg"
-  "msg/RefLine.msg"
+  "msg/Way.msg"
+  "msg/LaneletWay.msg"
   "msg/RegulatoryElement.msg"
   "msg/Lanelet.msg"
   "msg/LaneletAhead.msg"

--- a/src/world_modeling/lanelet_msgs/msg/Lanelet.msg
+++ b/src/world_modeling/lanelet_msgs/msg/Lanelet.msg
@@ -57,5 +57,8 @@ int64 right_lane_id
 # Successor lanelet IDs (what comes after this lanelet)
 int64[] successor_ids
 
+# Conflicting lanelet IDs (lanelets whose paths cross this one, e.g. at intersections)
+int64[] conflicting_lanelet_ids
+
 # Regulatory Elements (generic array - check subtype for specific types)
 RegulatoryElement[] regulatory_elements

--- a/src/world_modeling/lanelet_msgs/msg/LaneletWay.msg
+++ b/src/world_modeling/lanelet_msgs/msg/LaneletWay.msg
@@ -1,0 +1,9 @@
+# LaneletWay.msg
+# A way associated with one or more lanelets.
+#
+# Used for ref_lines (stop lines) in regulatory elements, where a single
+# stop line may span multiple lanelets and consumers need to know which
+# lanelets it applies to.
+
+Way way
+int64[] lanelet_ids

--- a/src/world_modeling/lanelet_msgs/msg/RefLine.msg
+++ b/src/world_modeling/lanelet_msgs/msg/RefLine.msg
@@ -1,7 +1,0 @@
-# RefLine.msg
-# A reference line within a lanelet (e.g., stop line).
-#
-# Contains the line geometry and its distance along the lanelet.
-
-geometry_msgs/Point[] points
-float64 distance_along_lanelet_m

--- a/src/world_modeling/lanelet_msgs/msg/RegulatoryElement.msg
+++ b/src/world_modeling/lanelet_msgs/msg/RegulatoryElement.msg
@@ -9,12 +9,11 @@ int64 id
 # Subtype: "traffic_light", "stop_sign", "yield", "right_of_way", "speed_limit"
 string subtype
 
-# Referred geometry (traffic lights, signs): IDs and 3D positions (parallel arrays)
-int64[] refers_ids
-geometry_msgs/Point[] refers_positions
+# Referred primitives (traffic lights, signs, etc.)
+Way[] refers
 
-# Reference lines (stop lines)
-RefLine[] ref_lines
+# Reference lines (stop lines) with lanelet association
+LaneletWay[] ref_lines
 
 # Yield relationships
 int64[] yield_lanelet_ids

--- a/src/world_modeling/lanelet_msgs/msg/Way.msg
+++ b/src/world_modeling/lanelet_msgs/msg/Way.msg
@@ -1,0 +1,8 @@
+# Way.msg
+# A linestring primitive from the lanelet2 map.
+#
+# Represents any ordered sequence of points with a unique map ID:
+# lane boundaries, stop lines, traffic light outlines, sign geometries, etc.
+
+int64 id
+geometry_msgs/Point[] points

--- a/src/world_modeling/world_model/include/world_model/lanelet_handler.hpp
+++ b/src/world_modeling/world_model/include/world_model/lanelet_handler.hpp
@@ -240,7 +240,7 @@ public:
    * @brief Build a RegulatoryElement message for a given regulatory element ID.
    *
    * Looks up the regulatory element in the map and populates the message with
-   * subtype, refers positions, ref lines (with distance_along_lanelet_m = 0),
+   * subtype, refers (as Ways), ref lines (as LaneletWays),
    * yield/right-of-way IDs, and generic attributes.
    *
    * @param reg_elem_id Regulatory element ID to look up.


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->
This PR makes the following tweaks to world model:
- Refline -> Way (which is a native lanelet primitive)
- LaneletWay is a Way message but with a lanelet id tied to it (helps BT)
- Lanelet.msg has a conflicting lanelet ids list now
- Bug fix with simulation not computing sensor yaw properly.

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section
