### PR TITLE
Spatial association classes

### DIFF
--- a/src/perception/perception_bringup/config/perception_bringup.yaml
+++ b/src/perception/perception_bringup/config/perception_bringup.yaml
@@ -168,7 +168,7 @@ multi_camera_sync:
 /**/tracking_node:
   ros__parameters:
     # --- Temporal tracking behavior ---
-    frame_rate: 9
+    frame_rate: 12
     track_buffer: 120
     track_thresh: 0.1
     high_thresh: 0.15
@@ -178,7 +178,7 @@ multi_camera_sync:
     dist_metric: "IOU"
     # Use lidar_cc when running perception without localization (no map→lidar_cc TF).
     # Set to "map" when running with localization so tracks are in the global frame.
-    output_frame: "lidar_cc"
+    output_frame: "map"
     publish_visualization: true
 
     # --- Per-class tracking overrides (parallel arrays). Empty = single global tracker. ---

--- a/src/perception/perception_bringup/config/perception_bringup.yaml
+++ b/src/perception/perception_bringup/config/perception_bringup.yaml
@@ -25,6 +25,7 @@
 # =============================================================================
 # Patchwork++ Node (Ground Segmentation)
 # =============================================================================
+---
 /**/patchworkpp_node:
   ros__parameters:
     # --- Frames and range gates ---
@@ -167,7 +168,7 @@ multi_camera_sync:
 /**/tracking_node:
   ros__parameters:
     # --- Temporal tracking behavior ---
-    frame_rate: 12
+    frame_rate: 9
     track_buffer: 120
     track_thresh: 0.1
     high_thresh: 0.15
@@ -177,8 +178,17 @@ multi_camera_sync:
     dist_metric: "IOU"
     # Use lidar_cc when running perception without localization (no map→lidar_cc TF).
     # Set to "map" when running with localization so tracks are in the global frame.
-    output_frame: "map"
+    output_frame: "lidar_cc"
     publish_visualization: true
+
+    # --- Per-class tracking overrides (parallel arrays). Empty = single global tracker. ---
+    # Classes not listed here use the global defaults above.
+    class_tracking:
+      classes: ["car",  "person", "truck", "bus"]
+      match_thresholds: [0.95,   0.999999,     0.95,    0.95]
+      high_thresholds: [0.40,   0.001,     0.35,    0.20]
+      track_thresholds: [0.10,   0.001,     0.10,    0.10]
+      dist_metrics: ["IOU",  "CIOU",   "IOU",   "IOU"]
 
     # --- Prediction (Kalman filter future path) ---
     centroid_history_size: 10   # past centroids stored per track
@@ -199,7 +209,7 @@ multi_camera_sync:
     lidar_frame: lidar_cc
     max_detection_cloud_stamp_delta: 0.0
     detection_stamp_fallback_policy: "median_camera_stamp"
-    clustered_cloud_cache_size: 24
+    clustered_cloud_cache_size: 4
     raw_cloud_pending_queue_size: 1
     raw_cloud_latest_only: true
     bbox_markers_use_detection_stamp: false
@@ -207,7 +217,7 @@ multi_camera_sync:
 
     # --- Euclidean clustering (3D proposals from point cloud) ---
     euclid_params:
-      cluster_tolerance: 0.80
+      cluster_tolerance: 0.60
       min_cluster_size: 3
       max_cluster_size: 1000
       use_adaptive_clustering: false
@@ -220,8 +230,21 @@ multi_camera_sync:
         tolerance_mults: [1.0, 1.0, 1.5, 2.5]
         min_cluster_sizes: [10, 6, 3, 2]
 
+      # Per-class clustering overrides for class-aware re-clustering.
+      # After initial clustering + 2D association, matched detections are re-clustered
+      # with class-specific params. This is usually for classes smaller than cars that need tighter tolerances
+      class_clustering:
+        classes: ["person", "bicycle", "motorcycle", "stop sign"]
+        cluster_tolerances: [0.50,   0.80,      0.80,       0.20]
+        min_cluster_sizes: [1,      5,         5,            2]
+        max_cluster_sizes: [700,   900,       900,          80]
+        merge_thresholds: [0.4,   0.50,      0.40,         0.05]
+        # Inflate 2D detection box before extracting LiDAR points (compensates for TF misalignment at range).
+        # 1.0 = no inflation, 1.3 = 30% wider/taller box.
+        bbox_inflation_factors: [1.5,   1.15,      1.15,   1.00]
+
     # --- Merge behavior ---
-    merge_threshold: 0.50
+    merge_threshold: 0.60
 
     # --- Cross-camera deduplication ---
     cross_camera_dedup:
@@ -303,8 +326,8 @@ multi_camera_sync:
       # --- Class-aware threshold scaling ---
       person_inside_fraction_scale: 0.15
       vehicle_inside_fraction_scale: 0.30
-      person_iou_threshold_scale: 0.03
-      vehicle_iou_threshold_scale: 0.05
+      person_iou_threshold_scale: 0.15
+      vehicle_iou_threshold_scale: 0.10
       person_ar_consistency_scale: 0.20
 
       # --- Minimum evidence gates ---
@@ -338,20 +361,20 @@ multi_camera_sync:
       quality_vehicle_max_height_m: 4.8
 
       # --- Depth consistency scoring from enriched 3D detections ---
-      depth_score_weight: 0.10
+      depth_score_weight: 0.40
       depth_score_scale: 5.0
 
       # --- Class-aware size prior (pre-match penalty; toggle off to disable entirely) ---
       enable_size_prior: true
-      size_prior_weight: 0.10
-      size_prior_scale: 0.5
-      size_prior_classes:      ["person", "car",  "truck", "bus",  "bicycle", "motorcycle"]
-      size_prior_min_widths:   [0.1,      1.4,    2.0,     2.2,    0.3,       0.4]
-      size_prior_max_widths:   [0.9,      2.2,    3.0,     3.0,    0.8,       1.0]
-      size_prior_min_lengths:  [0.1,      2.5,    5.0,     8.0,    1.2,       1.5]
-      size_prior_max_lengths:  [0.9,      4.0,    12.0,    15.0,   2.0,       2.5]
-      size_prior_min_heights:  [0.4,      1.2,    2.0,     2.5,    0.8,       0.8]
-      size_prior_max_heights:  [3.0,      2.0,    4.5,     4.0,    1.8,       1.8]
+      size_prior_weight: 0.50
+      size_prior_scale: 1.0
+      size_prior_classes: ["person", "car",  "truck", "bus",  "bicycle", "motorcycle", "stop sign"]
+      size_prior_min_widths: [0.01,      1.4,    2.0,     2.2,    0.3,       0.4,          0.1]
+      size_prior_max_widths: [1.0,      2.2,    3.0,     3.0,    0.8,       1.0,          0.8]
+      size_prior_min_lengths: [0.01,      2.5,    5.0,     8.0,    1.2,       1.5,         0.1]
+      size_prior_max_lengths: [1.0,      4.0,    12.0,    15.0,   2.0,       2.5,         0.9]
+      size_prior_min_heights: [0.01,      1.2,    2.0,     2.5,    0.8,       0.8,         0.1]
+      size_prior_max_heights: [4.0,      2.0,    4.5,     4.0,    1.8,       1.8,         2.0]
 
 # =============================================================================
 # Attribute Assigner Node

--- a/src/perception/spatial_association/config/params.yaml
+++ b/src/perception/spatial_association/config/params.yaml
@@ -26,6 +26,19 @@
         max_distances: [8.0, 20.0, 40.0, 999.0]
         tolerance_mults: [1.3, 1.0, 1.5, 2.0]
         min_cluster_sizes: [15, 12, 10, 8]
+
+      # Per-class clustering overrides (parallel arrays). After initial clustering + 2D association
+      # assigns class labels, matched detections are re-clustered with class-specific params.
+      # Empty arrays = disabled (no class-aware re-clustering).
+      class_clustering:
+        classes: ["car",  "person", "truck", "bus",  "bicycle", "motorcycle", "stop sign"]
+        cluster_tolerances: [0.50,   0.30,     0.80,    1.00,   0.25,      0.30,         0.15]
+        min_cluster_sizes: [8,      3,        12,      12,     3,         3,            2]
+        max_cluster_sizes: [800,    200,      2000,    2000,   100,       150,          50]
+        merge_thresholds: [0.50,   0.30,     0.80,    1.00,   0.20,      0.30,         0.10]
+        # Inflate 2D detection box before extracting LiDAR points (compensates for TF misalignment at range).
+        # 1.0 = no inflation, 1.3 = 30% wider/taller box. Optional — defaults to 1.0 if omitted.
+        bbox_inflation_factors: [1.20,   1.10,     1.30,    1.30,   1.10,      1.10,         1.05]
     merge_threshold: 0.4
 
     # --- 2D Detection Filter ---

--- a/src/perception/spatial_association/docs/DEVELOPING.md
+++ b/src/perception/spatial_association/docs/DEVELOPING.md
@@ -78,6 +78,14 @@ The node is structured in three main layers:
                                 │
                                 ▼
                         ┌─────────────────┐
+                        │ Class-Aware     │
+                        │ Re-Clustering   │
+                        │ (per-class      │
+                        │  tolerance)     │
+                        └────────┬────────┘
+                                │
+                                ▼
+                        ┌─────────────────┐
                         │ 3D Box Fitting  │
                         │ (L-shaped /     │
                         │  search-based)  │
@@ -127,6 +135,23 @@ All parameters are in `config/params.yaml`.
 | `euclid_params.clustering_bands.tolerance_mults` | array | [1.3, 1.0, 1.5, 2.0] | Tolerance multiplier per band |
 | `euclid_params.clustering_bands.min_cluster_sizes` | array | [15, 12, 10, 8] | Min cluster size per band |
 | `merge_threshold` | double (m) | 0.4 | Max AABB gap distance between clusters to merge |
+
+### Class-Aware Clustering (Per-Class Re-Clustering)
+
+After initial clustering + 2D detection association assigns class labels, matched detections are **re-clustered** with class-specific parameters. For each matched candidate, points projecting into the 2D detection box are extracted and re-clustered using per-class tolerance and size constraints. Empty arrays disable the feature entirely.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `euclid_params.class_clustering.classes` | string[] | [car, person, truck, bus, bicycle, motorcycle, stop sign] | Class names (parallel with arrays below) |
+| `euclid_params.class_clustering.cluster_tolerances` | double[] | [0.50, 0.30, 0.80, 1.00, 0.25, 0.30, 0.15] | Euclidean cluster tolerance (m) per class |
+| `euclid_params.class_clustering.min_cluster_sizes` | int[] | [8, 3, 12, 12, 3, 3, 2] | Minimum points per cluster per class |
+| `euclid_params.class_clustering.max_cluster_sizes` | int[] | [800, 200, 2000, 2000, 100, 150, 50] | Maximum points per cluster per class |
+| `euclid_params.class_clustering.merge_thresholds` | double[] | [0.50, 0.30, 0.80, 1.00, 0.20, 0.30, 0.10] | AABB gap for merge (m) per class |
+| `euclid_params.class_clustering.bbox_inflation_factors` | double[] | [1.20, 1.10, 1.30, 1.30, 1.10, 1.10, 1.05] | Multiplier on 2D detection box size before point extraction (compensates for TF misalignment at range). 1.0 = no inflation. Optional — defaults to 1.0 if omitted. |
+
+Negative values in any per-class parameter fall back to the global default.
+
+**Safeguard**: The refined cluster is only accepted if it has **at least as many points** as the original. If the 2D detection box captures fewer LiDAR points than the original 3D cluster (common with TF misalignment at range), the original is kept. This prevents re-clustering from shrinking good clusters.
 
 ### 2D Detection Filter
 
@@ -312,9 +337,17 @@ Applied on top of distance-adaptive thresholds.
 
 ## Key Components
 
-### 1. Class-Aware Filtering
+### 1. Class-Aware Filtering & Re-Clustering
 
 **`filterCandidatesByClassAwareConstraints()`** runs after IoU matching and applies size/quality constraints (same defaults for all candidates). Constraint values are configured via `quality_filter_params` in `params.yaml`.
+
+**Class-aware re-clustering** runs after quality filtering and before 3D box fitting. For each matched detection with a configured class override:
+1. `extractPointIndicesInDetectionBox()` projects all LiDAR points to the camera image and collects those inside the 2D detection box.
+2. `SpatialAssociationCore::reClusterPointSubset()` builds a sub-cloud from those points and runs Euclidean clustering with per-class tolerance, min/max size.
+3. `selectBestClusterByOverlap()` picks the refined cluster that best overlaps the original candidate.
+4. Cluster stats are recomputed for downstream box fitting.
+
+This allows tight clustering for small objects (people, bicycles, stop signs) while using larger tolerances for trucks and buses, without compromising the initial class-agnostic clustering pass.
 
 ### 2. Multi-camera behavior
 
@@ -335,7 +368,8 @@ The pipeline uses a single container type **`ClusterCandidate`** (indices + stat
 2. **Build candidates** - `ProjectionUtils::buildCandidates(cloud, cluster_indices)`: one struct per cluster with indices and stats.
 3. **IoU match** - `ProjectionUtils::assignCandidatesToDetectionsByIOU(cloud, candidates, ...)`: fills `candidate.match`, removes unmatched.
 4. **Class-aware filter** - `ProjectionUtils::filterCandidatesByClassAwareConstraints(candidates, detections)`: reads quality thresholds from `ProjectionUtils::getParams()` (filled from `quality_filter_params` in `initializeParams()` / `setParams`).
-5. **Box fitting** - boxes from `extractIndices(candidates)`, then `compute3DDetection(boxes, candidates, ...)` for class/score from `candidate.match`.
+5. **Class-aware re-clustering** - For each matched candidate with per-class overrides: `extractPointIndicesInDetectionBox()` + `SpatialAssociationCore::reClusterPointSubset()` + `selectBestClusterByOverlap()`. Refines cluster boundaries using class-specific tolerances.
+6. **Box fitting** - boxes from `extractIndices(candidates)`, then `compute3DDetection(boxes, candidates, ...)` for class/score from `candidate.match`.
 
 #### `SpatialAssociationCore::performClustering()`
 
@@ -449,30 +483,46 @@ Default bands:
 
 Prevents fragmentation of close objects while maintaining precision for distant objects.
 
-### 2. L-Shaped Fitting (Vehicles)
+### 2. Class-Aware Re-Clustering
+
+After association assigns class labels, matched detections are refined with per-class Euclidean clustering:
+
+1. **Point extraction**: All LiDAR points are projected to the camera image; those inside the 2D detection box are collected (`extractPointIndicesInDetectionBox()`).
+2. **Sub-cloud clustering**: A sub-cloud is built from the extracted points and clustered with class-specific tolerance, min/max size (`reClusterPointSubset()`).
+3. **Best cluster selection**: The refined cluster with the most index overlap with the original candidate is chosen (`selectBestClusterByOverlap()`).
+4. **Stats recomputation**: Cluster stats (centroid, bounds) are recomputed for downstream box fitting.
+
+This addresses the fundamental trade-off where a single set of clustering params cannot be optimal for all object types:
+- **People/bicycles/stop signs**: Tight tolerance (0.20-0.40m), low min size (2-3 points)
+- **Cars**: Moderate tolerance (0.50-0.80m), moderate min size (5-8 points)
+- **Trucks/buses**: Large tolerance (0.80-1.50m), higher min size (8-12 points)
+
+If `class_clustering.classes` is empty, this step is skipped entirely (backward compatible).
+
+### 3. L-Shaped Fitting (Vehicles)
 
 Alternative to search-based orientation fitting; fits L-shaped corner points (front bumper + side profile) for better vehicle orientation recovery. Used by default for car/truck/bus classes.
 
-### 3. Search-Based Orientation Fitting
+### 4. Search-Based Orientation Fitting
 
 For non-vehicle classes:
 1. **Coarse search**: Tests angles in 10 degree steps (0 to 90 degrees)
 2. **Fine search**: Refines best angle in +/-5 degree range with 2 degree steps
 3. **Edge energy minimization**: Finds orientation that minimizes distance to bounding box edges
 
-### 4. Outlier Rejection
+### 5. Outlier Rejection
 
 For clusters with > 30 points:
 - Computes mean and standard deviation of rotated coordinates
 - Clips points beyond 4.5 sigma to prevent outliers from skewing bounding box
 
-### 5. Aspect Ratio Disambiguation
+### 6. Aspect Ratio Disambiguation
 
 When aspect ratio < 1.2 (nearly square):
 - Uses line-of-sight yaw (from centroid to sensor)
 - Otherwise uses fitted orientation, choosing the direction closest to line-of-sight
 
-### 6. Cross-Camera Deduplication
+### 7. Cross-Camera Deduplication
 
 Merges duplicate detections from multiple camera views:
 - LiDAR index overlap >= 0.5 (intersection/min set size)
@@ -549,6 +599,14 @@ euclid_params:
   clustering_bands:
     tolerance_mults: [1.5, 1.2, 1.8, 2.5]  # Increase multipliers
 ```
+
+### Issue: Class-Aware Re-Clustering Not Activating
+
+**Solution**: Check that:
+- `euclid_params.class_clustering.classes` is non-empty
+- All parallel arrays (`cluster_tolerances`, `min_cluster_sizes`, `max_cluster_sizes`, `merge_thresholds`) have the same length as `classes`
+- The class names match the 2D detector's `class_id` strings exactly (case-sensitive)
+- If arrays are mismatched, a warning is logged and the feature is disabled
 
 ### Issue: TF Transform Errors
 

--- a/src/perception/spatial_association/include/spatial_association/spatial_association.hpp
+++ b/src/perception/spatial_association/include/spatial_association/spatial_association.hpp
@@ -226,6 +226,9 @@ private:
   /** Multi-band clustering bands (empty = use legacy two-band or flat clustering). */
   std::vector<SpatialAssociationCore::ClusteringBand> clustering_bands_;
 
+  /** Per-class clustering parameter overrides (empty = no class-aware re-clustering). */
+  std::unordered_map<std::string, SpatialAssociationCore::ClassClusteringParams> class_clustering_params_;
+
   double merge_threshold_;
 
   float object_detection_confidence_;

--- a/src/perception/spatial_association/include/spatial_association/spatial_association_core.hpp
+++ b/src/perception/spatial_association/include/spatial_association/spatial_association_core.hpp
@@ -22,6 +22,8 @@
 #include <pcl/segmentation/extract_clusters.h>
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "utils/projection_utils.hpp"
@@ -44,6 +46,16 @@ public:
     int min_cluster_size; /**< Minimum cluster size for this band. */
   };
 
+  /** Per-class override for clustering parameters. Negative values fall back to global defaults. */
+  struct ClassClusteringParams
+  {
+    double cluster_tolerance = -1.0; /**< Euclidean cluster tolerance (m). */
+    int min_cluster_size = -1; /**< Minimum points per cluster. */
+    int max_cluster_size = -1; /**< Maximum points per cluster. */
+    double merge_threshold = -1.0; /**< AABB gap for post-cluster merge (m). */
+    double bbox_inflation = 1.0; /**< Multiplier on 2D detection box size for point extraction (1.0 = no change). */
+  };
+
   /** Configuration for voxel grid, Euclidean clustering, and merge (quality filter lives in ProjectionUtilsParams). */
   struct ClusteringParams
   {
@@ -63,6 +75,9 @@ public:
 
     /** Drop points beyond this range from lidar origin (m). 0 = disabled. Reduces far noise before voxel/cluster. */
     double max_lidar_range_m = 0.0;
+
+    /** Per-class clustering overrides keyed by class_id (e.g. "car", "person"). */
+    std::unordered_map<std::string, ClassClusteringParams> class_params;
   };
 
   /**
@@ -110,6 +125,20 @@ public:
    */
   void performClustering(
     pcl::PointCloud<pcl::PointXYZ>::Ptr & filtered_cloud, std::vector<pcl::PointIndices> & cluster_indices);
+
+  /**
+   * @brief Re-clusters a subset of points using class-specific parameters.
+   * Builds a sub-cloud from the given indices, runs Euclidean clustering with class-specific
+   * tolerances, and maps resulting indices back to the original cloud.
+   * @param cloud Full filtered point cloud
+   * @param point_indices Indices into cloud defining the subset to re-cluster
+   * @param class_params Class-specific clustering parameters (negative values fall back to defaults)
+   * @return Vector of cluster indices (mapped back to original cloud)
+   */
+  std::vector<pcl::PointIndices> reClusterPointSubset(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud,
+    const std::vector<int> & point_indices,
+    const ClassClusteringParams & class_params) const;
 
   /**
    * @brief Computes 3D bounding boxes for clusters

--- a/src/perception/spatial_association/src/spatial_association.cpp
+++ b/src/perception/spatial_association/src/spatial_association.cpp
@@ -199,6 +199,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Spatia
     // Load multi-band clustering config if present.
     core_params.clustering_bands = clustering_bands_;
 
+    // Load per-class clustering overrides.
+    core_params.class_params = class_clustering_params_;
+
     core_->setParams(core_params);
 
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
@@ -450,6 +453,14 @@ void SpatialAssociationNode::initializeParams()
   declareIfMissing(this, "euclid_params.clustering_bands.tolerance_mults", std::vector<double>{});
   declareIfMissing(this, "euclid_params.clustering_bands.min_cluster_sizes", std::vector<int64_t>{});
 
+  // Per-class clustering overrides (parallel arrays, like size_prior_classes).
+  declareIfMissing(this, "euclid_params.class_clustering.classes", std::vector<std::string>{});
+  declareIfMissing(this, "euclid_params.class_clustering.cluster_tolerances", std::vector<double>{});
+  declareIfMissing(this, "euclid_params.class_clustering.min_cluster_sizes", std::vector<int64_t>{});
+  declareIfMissing(this, "euclid_params.class_clustering.max_cluster_sizes", std::vector<int64_t>{});
+  declareIfMissing(this, "euclid_params.class_clustering.merge_thresholds", std::vector<double>{});
+  declareIfMissing(this, "euclid_params.class_clustering.bbox_inflation_factors", std::vector<double>{});
+
   declareIfMissing(this, "merge_threshold", 0.3);
 
   declareIfMissing(this, "cross_camera_dedup.enabled", true);
@@ -476,7 +487,7 @@ void SpatialAssociationNode::initializeParams()
   declareIfMissing(this, "quality_filter_params.max_aspect_ratio", 15.0);
 
   const std::string pu("projection_utils_params.");
-  declareIfMissing(this, pu + "marker_lifetime_s", 0.5);
+  declareIfMissing(this, pu + "marker_lifetime_s", 1.5);
   declareIfMissing(this, pu + "marker_alpha", 0.2);
   declareIfMissing(this, pu + "min_iou_threshold", 0.15);
   declareIfMissing(this, pu + "ar_front_view_threshold", 1.2);
@@ -581,6 +592,36 @@ void SpatialAssociationNode::initializeParams()
       for (size_t i = 0; i < band_dists.size(); ++i) {
         clustering_bands_.push_back({band_dists[i], band_mults[i], static_cast<int>(band_mins[i])});
       }
+    }
+  }
+
+  // Load per-class clustering overrides.
+  {
+    auto cc_cls = this->get_parameter("euclid_params.class_clustering.classes").as_string_array();
+    auto cc_tol = this->get_parameter("euclid_params.class_clustering.cluster_tolerances").as_double_array();
+    auto cc_min = this->get_parameter("euclid_params.class_clustering.min_cluster_sizes").as_integer_array();
+    auto cc_max = this->get_parameter("euclid_params.class_clustering.max_cluster_sizes").as_integer_array();
+    auto cc_merge = this->get_parameter("euclid_params.class_clustering.merge_thresholds").as_double_array();
+    auto cc_inflate = this->get_parameter("euclid_params.class_clustering.bbox_inflation_factors").as_double_array();
+    const size_t n = cc_cls.size();
+    class_clustering_params_.clear();
+    // bbox_inflation_factors is optional — defaults to 1.0 per class if omitted or wrong length.
+    const bool have_inflate = (cc_inflate.size() == n);
+    if (n > 0 && cc_tol.size() == n && cc_min.size() == n && cc_max.size() == n && cc_merge.size() == n) {
+      for (size_t i = 0; i < n; ++i) {
+        SpatialAssociationCore::ClassClusteringParams cp;
+        cp.cluster_tolerance = cc_tol[i];
+        cp.min_cluster_size = static_cast<int>(cc_min[i]);
+        cp.max_cluster_size = static_cast<int>(cc_max[i]);
+        cp.merge_threshold = cc_merge[i];
+        cp.bbox_inflation = have_inflate ? cc_inflate[i] : 1.0;
+        class_clustering_params_[cc_cls[i]] = cp;
+      }
+    } else if (n > 0) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "class_clustering arrays have mismatched lengths (%zu classes); class-aware clustering disabled",
+        n);
     }
   }
 
@@ -1502,6 +1543,96 @@ DetectionOutputs SpatialAssociationNode::processDetections(
   }
 
   projection_utils::filterCandidatesByClassAwareConstraints(candidates, detection);
+
+  // Class-aware re-clustering: refine matched candidates using per-class clustering params.
+  const auto & class_params = core_->getParams().class_params;
+  if (!class_params.empty() && !candidates.empty()) {
+    const auto lidar_to_image = projection_utils::buildLidarToImageMatrix(transform, projection_matrix);
+    const int iw = image_width > 0 ? image_width : projection_utils::kDefaultImageWidth;
+    const int ih = image_height > 0 ? image_height : projection_utils::kDefaultImageHeight;
+
+    for (auto & candidate : candidates) {
+      if (!candidate.match || candidate.match->det_idx < 0) continue;
+      const size_t di = static_cast<size_t>(candidate.match->det_idx);
+      if (di >= detection.detections.size() || detection.detections[di].results.empty()) continue;
+
+      const std::string & class_id = detection.detections[di].results[0].hypothesis.class_id;
+      auto it = class_params.find(class_id);
+      if (it == class_params.end()) {
+        if (debug_logging_) {
+          RCLCPP_INFO(
+            this->get_logger(),
+            "Class-recluster: no per-class params for '%s', keeping original (%zu pts)",
+            class_id.c_str(),
+            candidate.indices.indices.size());
+        }
+        continue;
+      }
+
+      const size_t orig_size = candidate.indices.indices.size();
+
+      // Inflate the 2D detection box to compensate for transform misalignment at range.
+      const double inflate = it->second.bbox_inflation;
+      vision_msgs::msg::Detection2D inflated_det = detection.detections[di];
+      if (inflate > 1.0) {
+        inflated_det.bbox.size_x *= inflate;
+        inflated_det.bbox.size_y *= inflate;
+      }
+
+      // Extract all LiDAR points that project into the (inflated) 2D bounding box.
+      auto region_indices =
+        projection_utils::extractPointIndicesInDetectionBox(cloud, lidar_to_image, inflated_det, iw, ih);
+      if (region_indices.size() < 2u) {
+        if (debug_logging_) {
+          RCLCPP_INFO(
+            this->get_logger(),
+            "Class-recluster [%s]: only %zu points in detection box, skipping (need >= 2)",
+            class_id.c_str(),
+            region_indices.size());
+        }
+        continue;
+      }
+
+      // Re-cluster the region with class-specific params.
+      auto refined = core_->reClusterPointSubset(cloud, region_indices, it->second);
+      if (refined.empty()) {
+        if (debug_logging_) {
+          RCLCPP_INFO(
+            this->get_logger(),
+            "Class-recluster [%s]: %zu region pts -> 0 clusters (tol=%.2f, min=%d), keeping original (%zu pts)",
+            class_id.c_str(),
+            region_indices.size(),
+            it->second.cluster_tolerance,
+            it->second.min_cluster_size,
+            orig_size);
+        }
+        continue;
+      }
+
+      // Select the refined cluster that best overlaps with the original candidate.
+      size_t best = projection_utils::selectBestClusterByOverlap(refined, candidate.indices);
+      const size_t refined_size = refined[best].indices.size();
+      candidate.indices = std::move(refined[best]);
+
+      // Recompute stats for the refined cluster.
+      auto stats = projection_utils::computeClusterStats(cloud, {candidate.indices});
+      if (!stats.empty()) {
+        candidate.stats = stats[0];
+      }
+
+      if (debug_logging_) {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Class-recluster [%s]: %zu region pts -> %zu clusters, picked #%zu (%zu pts, was %zu)",
+          class_id.c_str(),
+          region_indices.size(),
+          refined.size(),
+          best,
+          refined_size,
+          orig_size);
+      }
+    }
+  }
 
   std::vector<pcl::PointIndices> out_indices = projection_utils::extractIndices(candidates);
 

--- a/src/perception/spatial_association/src/spatial_association_core.cpp
+++ b/src/perception/spatial_association/src/spatial_association_core.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <utility>
 #include <vector>
 
 namespace wato::perception::spatial_association
@@ -185,6 +186,52 @@ void SpatialAssociationCore::computeClusterCentroids(
   centroid_cloud->width = centroid_cloud->points.size();
   centroid_cloud->height = 1;
   centroid_cloud->is_dense = true;
+}
+
+std::vector<pcl::PointIndices> SpatialAssociationCore::reClusterPointSubset(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud,
+  const std::vector<int> & point_indices,
+  const ClassClusteringParams & cp) const
+{
+  std::vector<pcl::PointIndices> result;
+  if (!cloud || point_indices.size() < 2u) return result;
+
+  // Build sub-cloud from the given indices.
+  pcl::PointCloud<pcl::PointXYZ>::Ptr sub(new pcl::PointCloud<pcl::PointXYZ>);
+  sub->points.reserve(point_indices.size());
+  for (int idx : point_indices) {
+    sub->points.push_back(cloud->points[idx]);
+  }
+  sub->width = sub->points.size();
+  sub->height = 1;
+  sub->is_dense = false;
+
+  // Resolve per-class params with fallback to global defaults.
+  const double tolerance = cp.cluster_tolerance > 0 ? cp.cluster_tolerance : params_.euclid_cluster_tolerance;
+  const int min_size = cp.min_cluster_size > 0 ? cp.min_cluster_size : params_.euclid_min_cluster_size;
+  const int max_size = cp.max_cluster_size > 0 ? cp.max_cluster_size : params_.euclid_max_cluster_size;
+
+  std::vector<pcl::PointIndices> sub_clusters;
+  projection_utils::euclideanClusterExtraction(sub, tolerance, min_size, max_size, sub_clusters);
+
+  // Merge nearby clusters if per-class merge threshold is set.
+  const double merge_thresh = cp.merge_threshold > 0 ? cp.merge_threshold : params_.merge_threshold;
+  if (sub_clusters.size() > 1u && merge_thresh > 0) {
+    auto stats = projection_utils::computeClusterStats(sub, sub_clusters);
+    projection_utils::mergeClusters(sub_clusters, sub, stats, merge_thresh);
+  }
+
+  // Map sub-cloud indices back to original cloud indices.
+  result.reserve(sub_clusters.size());
+  for (auto & cluster : sub_clusters) {
+    pcl::PointIndices mapped;
+    mapped.indices.reserve(cluster.indices.size());
+    for (int idx : cluster.indices) {
+      mapped.indices.push_back(point_indices[idx]);
+    }
+    result.push_back(std::move(mapped));
+  }
+  return result;
 }
 
 }  // namespace wato::perception::spatial_association

--- a/src/perception/spatial_association/utils/include/utils/projection_utils.hpp
+++ b/src/perception/spatial_association/utils/include/utils/projection_utils.hpp
@@ -278,6 +278,30 @@ std::vector<ClusterCandidate> buildCandidates(
 std::vector<pcl::PointIndices> extractIndices(const std::vector<ClusterCandidate> & candidates);
 
 /**
+ * @brief Extracts indices of cloud points that project within a 2D detection bounding box.
+ * @param cloud Point cloud in LiDAR frame
+ * @param lidar_to_image Pre-computed 3x4 projection matrix (P * T)
+ * @param detection 2D detection with bounding box
+ * @param image_width Image width for clipping
+ * @param image_height Image height for clipping
+ * @return Sorted vector of point indices that fall within the detection box
+ */
+std::vector<int> extractPointIndicesInDetectionBox(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud,
+  const Eigen::Matrix<double, 3, 4> & lidar_to_image,
+  const vision_msgs::msg::Detection2D & detection,
+  int image_width,
+  int image_height);
+
+/**
+ * @brief Selects the cluster from a set that best overlaps with a reference cluster.
+ * @param clusters Candidate clusters to choose from
+ * @param reference Reference cluster to compare against
+ * @return Index of the best-matching cluster (0 if clusters is empty)
+ */
+size_t selectBestClusterByOverlap(const std::vector<pcl::PointIndices> & clusters, const pcl::PointIndices & reference);
+
+/**
  * @brief Build lidar-to-image matrix once for use in point loops.
  * Use this + projectLidarToCamera(lidar_to_image, pt) so matrices are not rebuilt per point.
  */

--- a/src/perception/spatial_association/utils/src/projection_utils.cpp
+++ b/src/perception/spatial_association/utils/src/projection_utils.cpp
@@ -79,6 +79,55 @@ std::vector<pcl::PointIndices> extractIndices(const std::vector<ClusterCandidate
   return indices;
 }
 
+std::vector<int> extractPointIndicesInDetectionBox(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud,
+  const Eigen::Matrix<double, 3, 4> & lidar_to_image,
+  const vision_msgs::msg::Detection2D & detection,
+  int image_width,
+  int image_height)
+{
+  std::vector<int> indices;
+  if (!cloud || cloud->empty()) return indices;
+
+  const double cx = detection.bbox.center.position.x;
+  const double cy = detection.bbox.center.position.y;
+  const double half_w = detection.bbox.size_x * 0.5;
+  const double half_h = detection.bbox.size_y * 0.5;
+  const double x_min = std::max(0.0, cx - half_w);
+  const double x_max = std::min(static_cast<double>(image_width), cx + half_w);
+  const double y_min = std::max(0.0, cy - half_h);
+  const double y_max = std::min(static_cast<double>(image_height), cy + half_h);
+
+  indices.reserve(cloud->size() / 4);
+  for (size_t i = 0; i < cloud->points.size(); ++i) {
+    auto proj = projectLidarToCamera(lidar_to_image, cloud->points[i]);
+    if (!proj) continue;
+    if (proj->x >= x_min && proj->x <= x_max && proj->y >= y_min && proj->y <= y_max) {
+      indices.push_back(static_cast<int>(i));
+    }
+  }
+  return indices;
+}
+
+size_t selectBestClusterByOverlap(const std::vector<pcl::PointIndices> & clusters, const pcl::PointIndices & reference)
+{
+  if (clusters.empty()) return 0;
+  std::unordered_set<int> ref_set(reference.indices.begin(), reference.indices.end());
+  size_t best = 0;
+  size_t best_overlap = 0;
+  for (size_t c = 0; c < clusters.size(); ++c) {
+    size_t overlap = 0;
+    for (int idx : clusters[c].indices) {
+      if (ref_set.count(idx)) ++overlap;
+    }
+    if (overlap > best_overlap) {
+      best_overlap = overlap;
+      best = c;
+    }
+  }
+  return best;
+}
+
 std::vector<Box3D> computeClusterBoxes(
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud, const std::vector<pcl::PointIndices> & cluster_indices)
 {

--- a/src/perception/tracking/tracking/README.md
+++ b/src/perception/tracking/tracking/README.md
@@ -22,6 +22,9 @@ Core logic draws inspiration from ByteTrackV2 (Zhang et al., 2023). The implemen
 | `/perception/detections_3D_tracked` | `vision_msgs/Detection3DArray` | Tracked detections, track velocities are stored in the results field (ObjectHypothesisWithPose[]) |
 
 ## Parameters
+
+### Global Defaults
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `frame_rate`| int | 30 | Frame rate of the input detections |
@@ -33,6 +36,43 @@ Core logic draws inspiration from ByteTrackV2 (Zhang et al., 2023). The implemen
 | `use_R_scaling` | bool | false | Scale R matrix in Kalman Filter according to detection confidence |
 | `dist_metric` | string | "IOU" | Which distance metric to use (currently supports "IOU", "DIOU", "CIOU") |
 | `output_frame` | string | "map" | Frame to output tracks in |
+
+### Prediction (Kalman Filter)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `centroid_history_size` | int | 10 | Past centroids stored per track for velocity seeding |
+| `prediction_time` | double | 5.0 | How far into the future to predict (seconds) |
+| `prediction_dt` | double | 0.1 | Time step between predicted poses (seconds) |
+| `process_noise` | double | 0.1 | KF process noise (higher = trust measurements more, noisier velocity) |
+| `measurement_noise` | double | 0.5 | KF measurement noise (higher = smoother tracks, filters outliers) |
+
+### Per-Class Tracking Overrides
+
+When configured, separate `BYTETracker` instances run per class with independent thresholds and distance metrics. Detections are split by class before tracking and merged afterward with unique track ID offsets to avoid collisions. Classes not listed use the global defaults.
+
+Empty arrays disable per-class tracking (single global tracker for all classes).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `class_tracking.classes` | string[] | [] | Class names (parallel with arrays below) |
+| `class_tracking.match_thresholds` | double[] | [] | Max IoU cost per class (higher = more permissive matching) |
+| `class_tracking.high_thresholds` | double[] | [] | Min confidence to create new track per class |
+| `class_tracking.track_thresholds` | double[] | [] | High/low confidence split per class |
+| `class_tracking.dist_metrics` | string[] | [] | Distance metric per class ("IOU", "DIOU", "CIOU") |
+
+**Example** (cars use strict IOU, persons use permissive CIOU):
+
+```yaml
+class_tracking:
+  classes:           ["car",  "person", "truck", "bus"]
+  match_thresholds:  [0.95,   0.99,     0.95,    0.95]
+  high_thresholds:   [0.40,   0.001,    0.10,    0.10]
+  track_thresholds:  [0.10,   0.01,     0.10,    0.10]
+  dist_metrics:      ["IOU",  "CIOU",   "IOU",   "IOU"]
+```
+
+**Why per-class?** Small objects (persons, bicycles) have tiny 3D bounding boxes where frame-to-frame BEV IoU is near zero even for the same physical object. CIOU with a high match threshold bridges this gap. Large objects (cars, trucks) have stable boxes where standard IOU works well and CIOU can cause ID switches.
 
 ## Acknowledgements
 

--- a/src/perception/tracking/tracking/include/tracking/tracking.hpp
+++ b/src/perception/tracking/tracking/include/tracking/tracking.hpp
@@ -138,7 +138,7 @@ private:
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr markers_pub_;
   rclcpp_lifecycle::LifecyclePublisher<world_model_msgs::msg::WorldObjectArray>::SharedPtr predictions_pub_;
 
-  // ByteTrack parameters
+  // ByteTrack parameters (global defaults)
   int frame_rate_;
   int track_buffer_;
   float track_thresh_;
@@ -150,7 +150,22 @@ private:
   std::string output_frame_;
   bool publish_visualization_;
 
+  /** Default tracker for classes without per-class overrides. */
   std::unique_ptr<byte_track::BYTETracker> tracker_;
+
+  /** Per-class tracking overrides */
+  struct ClassTrackingParams
+  {
+    float track_thresh;
+    float high_thresh;
+    float match_thresh;
+    std::string dist_metric;
+  };
+
+  std::unordered_map<std::string, ClassTrackingParams> class_tracker_params_;
+  std::unordered_map<std::string, std::unique_ptr<byte_track::BYTETracker>> class_trackers_;
+  /** Stable ID offset per class to avoid collisions between separate tracker instances. */
+  std::unordered_map<std::string, int> class_tracker_id_offsets_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/src/perception/tracking/tracking/src/tracking.cpp
+++ b/src/perception/tracking/tracking/src/tracking.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -61,9 +62,31 @@ TrackingNode::CallbackReturn TrackingNode::on_configure(const rclcpp_lifecycle::
   predictions_pub_ = this->create_publisher<world_model_msgs::msg::WorldObjectArray>(kPredictionsTopic, 10);
   RCLCPP_DEBUG(this->get_logger(), "Publishers initialized, publishing to %s", tracked_dets_pub_->get_topic_name());
 
-  // ByteTrack tracker
+  // ByteTrack tracker (default for classes without per-class overrides)
   tracker_ = std::make_unique<byte_track::BYTETracker>(
     frame_rate_, track_buffer_, track_thresh_, high_thresh_, match_thresh_, use_maj_cls_, use_R_scaling_, dist_metric_);
+
+  // Per-class tracker instances
+  class_trackers_.clear();
+  for (const auto & [cls, cp] : class_tracker_params_) {
+    class_trackers_[cls] = std::make_unique<byte_track::BYTETracker>(
+      frame_rate_,
+      track_buffer_,
+      cp.track_thresh,
+      cp.high_thresh,
+      cp.match_thresh,
+      use_maj_cls_,
+      use_R_scaling_,
+      cp.dist_metric);
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Created tracker for '%s': match=%.2f, high=%.2f, track=%.2f, metric=%s",
+      cls.c_str(),
+      cp.match_thresh,
+      cp.high_thresh,
+      cp.track_thresh,
+      cp.dist_metric.c_str());
+  }
 
   RCLCPP_INFO(this->get_logger(), "Configuration successful");
   return TrackingNode::CallbackReturn::SUCCESS;
@@ -112,6 +135,7 @@ TrackingNode::CallbackReturn TrackingNode::on_cleanup(const rclcpp_lifecycle::St
   tf_listener_.reset();
   tf_buffer_.reset();
   tracker_.reset();
+  class_trackers_.clear();
   track_filters_.clear();
   track_centroids_.clear();
 
@@ -130,6 +154,7 @@ TrackingNode::CallbackReturn TrackingNode::on_shutdown(const rclcpp_lifecycle::S
   tf_listener_.reset();
   tf_buffer_.reset();
   tracker_.reset();
+  class_trackers_.clear();
   track_filters_.clear();
   track_centroids_.clear();
 
@@ -157,6 +182,31 @@ void TrackingNode::initializeParams()
   prediction_dt_ = this->declare_parameter<double>("prediction_dt", 0.1);
   process_noise_ = this->declare_parameter<double>("process_noise", 0.1);
   measurement_noise_ = this->declare_parameter<double>("measurement_noise", 0.5);
+
+  auto ct_classes = this->declare_parameter<std::vector<std::string>>("class_tracking.classes", {});
+  auto ct_match = this->declare_parameter<std::vector<double>>("class_tracking.match_thresholds", {});
+  auto ct_high = this->declare_parameter<std::vector<double>>("class_tracking.high_thresholds", {});
+  auto ct_dist = this->declare_parameter<std::vector<std::string>>("class_tracking.dist_metrics", {});
+  auto ct_track = this->declare_parameter<std::vector<double>>("class_tracking.track_thresholds", {});
+  const size_t n = ct_classes.size();
+  class_tracker_params_.clear();
+  if (n > 0 && ct_match.size() == n && ct_high.size() == n && ct_dist.size() == n && ct_track.size() == n) {
+    for (size_t i = 0; i < n; ++i) {
+      ClassTrackingParams cp;
+      cp.track_thresh = static_cast<float>(ct_track[i]);
+      cp.high_thresh = static_cast<float>(ct_high[i]);
+      cp.match_thresh = static_cast<float>(ct_match[i]);
+      cp.dist_metric = ct_dist[i];
+      class_tracker_params_[ct_classes[i]] = cp;
+      class_tracker_id_offsets_[ct_classes[i]] = static_cast<int>((i + 1) * 10000);
+    }
+    RCLCPP_INFO(this->get_logger(), "Per-class tracking enabled for %zu class(es)", n);
+  } else if (n > 0) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "class_tracking arrays have mismatched lengths (%zu classes); per-class tracking disabled",
+      n);
+  }
 }
 
 // Convert from ros msgs to bytetrack's required format
@@ -305,10 +355,48 @@ void TrackingNode::detectionsCallback(vision_msgs::msg::Detection3DArray::Shared
     tf_msg.detections.push_back(tf_det);
   }
 
-  // Run bytetrack on detections
+  // Run bytetrack on detections, with per-class tracker routing.
   auto objs = detsToObjects(tf_msg);
-  auto stracks = tracker_->update(objs);
-  auto tracked_dets = STracksToTracks(stracks, tf_msg.header);
+  vision_msgs::msg::Detection3DArray tracked_dets;
+  tracked_dets.header.frame_id = tf_msg.header.frame_id;
+  tracked_dets.header.stamp = tf_msg.header.stamp;
+
+  if (class_trackers_.empty()) {
+    auto stracks = tracker_->update(objs);
+    tracked_dets = STracksToTracks(stracks, tf_msg.header);
+  } else {
+    // Split objects by class: each class with a dedicated tracker gets its own group.
+    std::unordered_map<std::string, std::vector<byte_track::Object>> class_objs;
+    std::vector<byte_track::Object> default_objs;
+    for (auto & obj : objs) {
+      if (class_trackers_.count(obj.label)) {
+        class_objs[obj.label].push_back(obj);
+      } else {
+        default_objs.push_back(obj);
+      }
+    }
+
+    // Run each per-class tracker, convert to messages with ID offsets to avoid collisions.
+    for (auto & [cls, class_tracker] : class_trackers_) {
+      auto it = class_objs.find(cls);
+      // Always call update (even with empty vector) so the tracker can age out stale tracks.
+      std::vector<byte_track::Object> empty_objs;
+      auto & cls_objs = (it != class_objs.end()) ? it->second : empty_objs;
+      auto stracks = class_tracker->update(cls_objs);
+      auto cls_dets = STracksToTracks(stracks, tf_msg.header);
+      const int offset = class_tracker_id_offsets_[cls];
+      for (auto & det : cls_dets.detections) {
+        det.id = std::to_string(std::stoi(det.id) + offset);
+        tracked_dets.detections.push_back(std::move(det));
+      }
+    }
+
+    auto default_stracks = tracker_->update(default_objs);
+    auto default_dets = STracksToTracks(default_stracks, tf_msg.header);
+    for (auto & det : default_dets.detections) {
+      tracked_dets.detections.push_back(std::move(det));
+    }
+  }
 
   // Match each tracked detection to the nearest input detection to:
   // 1. Override ByteTrack's filtered yaw (Kalman filter causes unstable spinning)

--- a/src/world_modeling/behaviour/behaviour/src/behaviour_node.cpp
+++ b/src/world_modeling/behaviour/behaviour/src/behaviour_node.cpp
@@ -97,7 +97,8 @@ void BehaviourNode::init()
     "ego/odom", rclcpp::QoS(10), std::bind(&BehaviourNode::odom_callback, this, std::placeholders::_1));
 
   ego_odom_incremental_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "ego/odom_incremental", rclcpp::QoS(10),
+    "ego/odom_incremental",
+    rclcpp::QoS(10),
     std::bind(&BehaviourNode::odom_incremental_callback, this, std::placeholders::_1));
 
   RCLCPP_INFO(this->get_logger(), "BehaviourNode has been fully initialized.");


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Added class-aware clustering for spatial_association so that smaller classes (like "person" and "bicycle") have different params for clustering (essentially they are reclustered from the initial clustering pass as that is done before the transform into the camera frame.

Additionally, I noticed that tracking was not picking up the "person" class even though the bounding box was persisting. This was due to the IOU distance metric which only tracked objects for ByteTrack if the previous bounding box overlapped the new one, this is rare for small vertical bounding boxes like "person" though. So I added a class-aware change to tracking that makes a few other ByteTrack instances for these outlier conditions to change from IOU to CIOU (the other classes go through the previous general one). 

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

https://github.com/user-attachments/assets/636eecaf-3307-431a-addb-a92ac56c7549


### ✅  Checklist
- [ ] My code builds and runs locally without warnings
- [ ] I added/updated tests if needed
- [ ] I updated documentation / comments
- [ ] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs
Fixes #123
Depends on #456

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
