### PR TITLE
Isaac ros camera optimizations

### DIFF
--- a/docker/perception.Dockerfile
+++ b/docker/perception.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${AMENT_WS}/src
 
 # Copy in source code needed for perception build
 RUN git clone https://github.com/WATonomous/deep_ros.git deep_ros && \
-    git clone https://github.com/WATonomous/camera_aravis2_nitros.git camera_aravis2_nitros -b nitros-support
+    git clone https://github.com/WATonomous/camera_aravis2_nitros.git camera_aravis2_nitros
 
 COPY src/perception perception
 

--- a/docker/perception.Dockerfile
+++ b/docker/perception.Dockerfile
@@ -10,6 +10,8 @@ WORKDIR ${AMENT_WS}/src
 
 # Copy in source code needed for perception build
 RUN git clone https://github.com/WATonomous/deep_ros.git deep_ros
+RUN git clone https://github.com/WATonomous/camera_aravis2_nitros.git camera_aravis2_nitros -b nitros-support
+
 COPY src/perception perception
 
 COPY src/world_modeling/world_model_msgs world_model_msgs
@@ -32,4 +34,23 @@ RUN apt-get update && \
     libnvinfer10 \
     libnvinfer-plugin10 \
     libnvonnxparsers10 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Isaac ROS (NITROS + image_proc + h264_encoder) for GPU-accelerated image
+# rectification and NVENC H.264 compression of the rectified stream.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
+    curl -fsSL https://isaac.download.nvidia.com/isaac-ros/repos.key \
+      | gpg --dearmor -o /usr/share/keyrings/nvidia-isaac-ros.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-isaac-ros.gpg] https://isaac.download.nvidia.com/isaac-ros/release-4.4 noble main" \
+      > /etc/apt/sources.list.d/nvidia-isaac-ros.list && \
+    curl -fsSL https://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+      | gpg --dearmor -o /usr/share/keyrings/nvidia-jetson.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/x86_64/noble r38.4 main" \
+      > /etc/apt/sources.list.d/nvidia-jetson.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ros-jazzy-isaac-ros-nitros \
+      ros-jazzy-isaac-ros-image-proc \
+      ros-jazzy-isaac-ros-h264-encoder && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/perception.Dockerfile
+++ b/docker/perception.Dockerfile
@@ -9,8 +9,8 @@ FROM ${BASE_IMAGE} AS source
 WORKDIR ${AMENT_WS}/src
 
 # Copy in source code needed for perception build
-RUN git clone https://github.com/WATonomous/deep_ros.git deep_ros
-RUN git clone https://github.com/WATonomous/camera_aravis2_nitros.git camera_aravis2_nitros -b nitros-support
+RUN git clone https://github.com/WATonomous/deep_ros.git deep_ros && \
+    git clone https://github.com/WATonomous/camera_aravis2_nitros.git camera_aravis2_nitros -b nitros-support
 
 COPY src/perception perception
 
@@ -27,6 +27,9 @@ COPY src/wato_test wato_test
 # NOTE: You should be relying on ROSDEP as much as possible
 # Use this stage as a last resort
 FROM ${BASE_IMAGE} AS dependencies
+
+# Use bash with pipefail so piped RUN commands (e.g. curl | gpg) fail loudly.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install TensorRT dependencies for deep_ros
 RUN apt-get update && \

--- a/src/interfacing/sensor_interfacing/DEVELOPING.md
+++ b/src/interfacing/sensor_interfacing/DEVELOPING.md
@@ -37,8 +37,10 @@ ros2 topic hz /lidar_nw/velodyne_points
 ros2 topic hz /novatel/oem7/bestpos
 ros2 topic hz /novatel/oem7/imu/data
 
-# Cameras (repeat for each of the 12 camera namespaces)
-ros2 topic hz /camera_pano_nn/image_raw
+# Cameras (NITROS pipeline; repeat for each of the 12 camera namespaces)
+ros2 topic hz /camera_pano_nn/image_raw           # raw frames
+ros2 topic hz /camera_pano_nn/image_rect          # GPU-rectified (Isaac ROS)
+ros2 topic hz /camera_pano_nn/image_rect_h264     # NVENC H.264
 ```
 
 ## Definition of Good Result

--- a/src/interfacing/sensor_interfacing/config/hikrobot_camera_config.yaml
+++ b/src/interfacing/sensor_interfacing/config/hikrobot_camera_config.yaml
@@ -24,7 +24,7 @@ x-common-settings: &common_settings
     AutoExposureTimeUpperLimit: 15000      # microseconds             ` - limit for motion blur
     GainShutPrior: "Shut"                  # Prioritize shutter speed over gain
     AcquisitionFrameRateEnable: true
-    AcquisitionFrameRate: 12.0
+    AcquisitionFrameRate: 20.0 # Limited to Lidar publish rate (30 may be possible in the future)
   AnalogControl:
     GainAuto: "Continuous"
     AutoGainLowerLimit: 0.0                # dB

--- a/src/interfacing/sensor_interfacing/docs/camera_bringup.md
+++ b/src/interfacing/sensor_interfacing/docs/camera_bringup.md
@@ -8,6 +8,8 @@ ros2 launch sensor_interfacing all_cameras_composed.yaml
 
 > NOTE: Because ROS2 does serialization/deserialization regardless of middleware (even with Zenoh SHM), using 12 cameras at once is not possible without having them inside the same component container alongside any nodes that require camera data. As a result, cameras are launched inside the perception docker container alongside any perception nodes. This makes it so that all nodes that require camera do not do any serialization/deserialization to get images.
 
+> NOTE: The camera pipeline runs on NVIDIA Isaac ROS (NITROS): frames are GPU-rectified (`isaac_ros_image_proc`) and the rectified stream is NVENC-encoded to H.264 on `image_rect_h264`, with an optional JPEG stream on `image_rect_compressed` (toggle via the `enable_jpeg` launch arg, which is CPU-bound).
+
 ## Computer specific
 
 The cameras are plugged into a switch that is connected to the main computer.

--- a/src/interfacing/sensor_interfacing/launch/all_cameras_composed.yaml
+++ b/src/interfacing/sensor_interfacing/launch/all_cameras_composed.yaml
@@ -25,6 +25,11 @@ launch:
       default: "$(find-pkg-share sensor_interfacing)/config/hikrobot_camera_config.yaml"
       description: "Hikrobot cameras configuration file"
 
+  - arg:
+      name: "enable_jpeg"
+      default: "true"
+      description: "Load the per-camera JPEG encoder (image_rect_compressed). CPU intensive; set false to disable."
+
   # Panorama Cameras (8 cameras)
   # camera 0 - pano NN
   - include:
@@ -38,6 +43,8 @@ launch:
           value: "Hikrobot-MV-CU013-80GC-DA8386098"
         - name: "cameras_config_file"
           value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
   # camera 1 - pano NE
   - include:
@@ -51,71 +58,83 @@ launch:
           value: "Hikrobot-MV-CU013-80GC-DA8386154"
         - name: "cameras_config_file"
           value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
-  # # camera 2 - pano EE
-  # - include:
-  #     file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
-  #     arg:
-  #       - name: "container_name"
-  #         value: "$(var container_name)"
-  #       - name: "camera_name"
-  #         value: "camera_pano_ee"
-  #       - name: "guid"
-  #         value: "Hikrobot-MV-CU013-80GC-DA8386084"
-  #       - name: "cameras_config_file"
-  #         value: "$(var cameras_config_file)"
+  # camera 2 - pano EE
+  - include:
+      file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
+      arg:
+        - name: "container_name"
+          value: "$(var container_name)"
+        - name: "camera_name"
+          value: "camera_pano_ee"
+        - name: "guid"
+          value: "Hikrobot-MV-CU013-80GC-DA8386084"
+        - name: "cameras_config_file"
+          value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
-  # # camera 3 - pano SE
-  # - include:
-  #     file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
-  #     arg:
-  #       - name: "container_name"
-  #         value: "$(var container_name)"
-  #       - name: "camera_name"
-  #         value: "camera_pano_se"
-  #       - name: "guid"
-  #         value: "Hikrobot-MV-CU013-80GC-DA8386152"
-  #       - name: "cameras_config_file"
-  #         value: "$(var cameras_config_file)"
+  # camera 3 - pano SE
+  - include:
+      file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
+      arg:
+        - name: "container_name"
+          value: "$(var container_name)"
+        - name: "camera_name"
+          value: "camera_pano_se"
+        - name: "guid"
+          value: "Hikrobot-MV-CU013-80GC-DA8386152"
+        - name: "cameras_config_file"
+          value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
   # camera 4 - pano SS
-  # - include:
-  #     file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
-  #     arg:
-  #       - name: "container_name"
-  #         value: "$(var container_name)"
-  #       - name: "camera_name"
-  #         value: "camera_pano_ss"
-  #       - name: "guid"
-  #         value: "Hikrobot-MV-CU013-80GC-DA8386134"
-  #       - name: "cameras_config_file"
-  #         value: "$(var cameras_config_file)"
+  - include:
+      file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
+      arg:
+        - name: "container_name"
+          value: "$(var container_name)"
+        - name: "camera_name"
+          value: "camera_pano_ss"
+        - name: "guid"
+          value: "Hikrobot-MV-CU013-80GC-DA8386134"
+        - name: "cameras_config_file"
+          value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
-  # # camera 5 - pano SW
-  # - include:
-  #     file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
-  #     arg:
-  #       - name: "container_name"
-  #         value: "$(var container_name)"
-  #       - name: "camera_name"
-  #         value: "camera_pano_sw"
-  #       - name: "guid"
-  #         value: "Hikrobot-MV-CU013-80GC-DA8386093"
-  #       - name: "cameras_config_file"
-  #         value: "$(var cameras_config_file)"
+  # camera 5 - pano SW
+  - include:
+      file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
+      arg:
+        - name: "container_name"
+          value: "$(var container_name)"
+        - name: "camera_name"
+          value: "camera_pano_sw"
+        - name: "guid"
+          value: "Hikrobot-MV-CU013-80GC-DA8386093"
+        - name: "cameras_config_file"
+          value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
-  # # camera 6 - pano WW
-  # - include:
-  #     file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
-  #     arg:
-  #       - name: "container_name"
-  #         value: "$(var container_name)"
-  #       - name: "camera_name"
-  #         value: "camera_pano_ww"
-  #       - name: "guid"
-  #         value: "Hikrobot-MV-CU013-80GC-DA8386110"
-  #       - name: "cameras_config_file"
-  #         value: "$(var cameras_config_file)"
+  # camera 6 - pano WW
+  - include:
+      file: "$(find-pkg-share sensor_interfacing)/launch/template_camera_load.yaml"
+      arg:
+        - name: "container_name"
+          value: "$(var container_name)"
+        - name: "camera_name"
+          value: "camera_pano_ww"
+        - name: "guid"
+          value: "Hikrobot-MV-CU013-80GC-DA8386110"
+        - name: "cameras_config_file"
+          value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
   # camera 7 - pano NW
   - include:
@@ -129,6 +148,8 @@ launch:
           value: "Hikrobot-MV-CU013-80GC-DA8386109"
         - name: "cameras_config_file"
           value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "$(var enable_jpeg)"
 
   # # Lower Cameras (4 cameras)
   # # camera 8 - lower NE
@@ -143,6 +164,8 @@ launch:
   #         value: "Hikrobot-MV-CU013-80GC-DA8386132"
   #       - name: "cameras_config_file"
   #         value: "$(var cameras_config_file)"
+  #       - name: "enable_jpeg"
+  #         value: "$(var enable_jpeg)"
 
   # # camera 9 - lower SE
   # - include:
@@ -156,6 +179,8 @@ launch:
   #         value: "Hikrobot-MV-CU013-80GC-DA8386083"
   #       - name: "cameras_config_file"
   #         value: "$(var cameras_config_file)"
+  #       - name: "enable_jpeg"
+  #         value: "$(var enable_jpeg)"
 
   # # camera 10 - lower SW
   # - include:
@@ -169,6 +194,8 @@ launch:
   #         value: "GEV-MV-CU013-80GC-DA8434466"
   #       - name: "cameras_config_file"
   #         value: "$(var cameras_config_file)"
+  #       - name: "enable_jpeg"
+  #         value: "$(var enable_jpeg)"
 
   # # camera 11 - lower NW
   # - include:
@@ -182,3 +209,5 @@ launch:
   #         value: "GEV-MV-CU013-80GC-DA8434479"
   #       - name: "cameras_config_file"
   #         value: "$(var cameras_config_file)"
+  #       - name: "enable_jpeg"
+  #         value: "$(var enable_jpeg)"

--- a/src/interfacing/sensor_interfacing/launch/template_camera_load.yaml
+++ b/src/interfacing/sensor_interfacing/launch/template_camera_load.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Template to load a single camera pipeline (driver + debayer + rectify) into
+# Template to load a single camera pipeline (NITROS driver + GPU rectify) into
 # an existing component container. Does NOT create a container.
 ---
 launch:
@@ -33,6 +33,11 @@ launch:
       default: "$(find-pkg-share sensor_interfacing)/config/hikrobot_camera_config.yaml"
       description: "Hikrobot cameras configuration file"
 
+  - arg:
+      name: "enable_jpeg"
+      default: "true"
+      description: "Load the JPEG encoder (image_rect_compressed). CPU intensive; set false to disable."
+
   - load_composable_node:
       target: $(var container_name)
       composable_node:
@@ -50,39 +55,72 @@ launch:
               value: "$(var camera_name)"
             - name: camera_info_urls
               value: ["$(find-pkg-share camera_calib)/config/$(var camera_name).yaml"]
+            - name: nitros_enable
+              value: true
             - name: $(var camera_name).image_raw.enable_pub_plugins
               value:
                 - "image_transport/raw"
 
-        - pkg: image_proc
-          plugin: image_proc::DebayerNode
-          name: debayer_$(var camera_name)
-          namespace: $(var camera_name)
-          extra_arg:
-            - name: use_intra_process_comms
-              value: "true"
-          param:
-            - name: image_color.enable_pub_plugins
-              value:
-                - "image_transport/raw"
-            - name: image_mono.enable_pub_plugins
-              value:
-                - "image_transport/raw"
-
-        - pkg: image_proc
-          plugin: image_proc::RectifyNode
+        - pkg: isaac_ros_image_proc
+          plugin: nvidia::isaac_ros::image_proc::RectifyNode
           name: rectify_$(var camera_name)
           namespace: $(var camera_name)
           extra_arg:
             - name: use_intra_process_comms
               value: "true"
           param:
-            - name: image_rect.compressed.format
-              value: "jpeg"
-            - name: image_rect.compressed.jpeg_quality
-              value: "90"
+            - name: output_width
+              value: 1280
+            - name: output_height
+              value: 1024
           remap:
-            - from: "image"
-              to: "image_color"
-            - from: "image_rect/compressed"
+            - from: "image_raw"
+              to: "image_raw/nitros"
+
+
+        - pkg: isaac_ros_h264_encoder
+          plugin: nvidia::isaac_ros::h264_encoder::EncoderNode
+          name: encoder_$(var camera_name)
+          namespace: $(var camera_name)
+          extra_arg:
+            - name: use_intra_process_comms
+              value: "true"
+          param:
+            - name: input_width
+              value: 1280
+            - name: input_height
+              value: 1024
+          remap:
+            - from: "image_raw"
+              to: "image_rect"
+            - from: "image_compressed"
+              to: "image_rect_h264"
+
+  # Standard image_transport JPEG encoder: republishes the raw rectified image
+  # as a compressed (JPEG) CompressedImage on image_rect_compressed. Loaded as a
+  # separate action so it can be toggled via the enable_jpeg arg (CPU intensive).
+  - load_composable_node:
+      if: $(var enable_jpeg)
+      target: $(var container_name)
+      composable_node:
+        - pkg: image_transport
+          plugin: image_transport::Republisher
+          name: jpeg_encoder_$(var camera_name)
+          namespace: $(var camera_name)
+          extra_arg:
+            - name: use_intra_process_comms
+              value: "true"
+          param:
+            - name: in_transport
+              value: "raw"
+            - name: out_transport
+              value: "compressed"
+            - name: out.compressed.format
+              value: "jpeg"
+            - name: out.compressed.jpeg_quality
+              value: 90
+          remap:
+            - from: "in"
+              to: "image_rect"
+            - from: "out/compressed"
               to: "image_rect_compressed"

--- a/src/interfacing/sensor_interfacing/package.xml
+++ b/src/interfacing/sensor_interfacing/package.xml
@@ -11,8 +11,8 @@
 
   <exec_depend>novatel_oem7_driver</exec_depend>
   <exec_depend>velodyne</exec_depend>
-  <exec_depend>camera_aravis2</exec_depend>
   <exec_depend>camera_calib</exec_depend>
+  <exec_depend>image_transport</exec_depend>
   <exec_depend>compressed_image_transport</exec_depend>
 
   <export>

--- a/src/perception/perception_bringup/launch/perception.launch.yaml
+++ b/src/perception/perception_bringup/launch/perception.launch.yaml
@@ -62,6 +62,8 @@ launch:
           value: "perception_container"
         - name: "cameras_config_file"
           value: "$(var cameras_config_file)"
+        - name: "enable_jpeg"
+          value: "true"
 
   # Load multi-camera sync into the shared container
   - load_composable_node:


### PR DESCRIPTION
Added Isaac ROS to the Perception Container. This means we now avoid copies and keep everything on the GPU, from the camera driver through rectification to compression.*

There is one caveat: no JPEG compression node for Isaac ROS. So currently there is an argument to enable the regular image proc compression node (after Isaac ROS rectification), this allows for disabling it when we no longer need to view JPEG images directly and can feed in the nitros topics directly to downstream object detection (like BEVFusion).


This is the toggle within the `all_cameras_composed.yaml` file
```
  - arg:
      name: "enable_jpeg"
      default: "true"
```

### 📑  Description
This was necessary as it cut down on CPU compute quite a lot (from 70% down to 20%), which means we can now run 8 cameras at 20fps without problems!

This PR also uncommented 5 cameras, so now 8 run on startup.

### 📹  (Optional) Video Demo of Changes
https://github.com/user-attachments/assets/103bc590-caf6-482e-9fb5-14b977069aef

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs
Depends on https://github.com/WATonomous/camera_aravis2_nitros/pull/1



### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
