### PR TITLE
BUG FIX: Patched gps flakiness

### DIFF
--- a/src/interfacing/sensor_interfacing/config/novatel_oem7_overrides.yaml
+++ b/src/interfacing/sensor_interfacing/config/novatel_oem7_overrides.yaml
@@ -20,8 +20,17 @@ receiver_init_commands:
   - "LOG BESTVELB ONTIME 0.1"
   - "LOG BESTGNSSVELB ONTIME 0.1"
   - "LOG BESTUTMB ONTIME 1"
-  - "LOG BESTGNSSPOSB ONTIME 0.1"
-  - "LOG PPPPOSB ONTIME 1"
+  # BESTGNSSPOS and PPPPOS are DISABLED: the driver maps their fixed-length,
+  # null-padded `stn_id` char buffer into a std::string field including the
+  # trailing '\0' bytes. fastcdr (used by rmw_zenoh) rejects strings with
+  # embedded nulls (BadParamException), which aborts the whole GPS node ~90ms
+  # after init -- this was the intermittent "GPS won't publish" crash. BESTPOS/
+  # BESTUTM use a fixed int8[4] stn_id and are unaffected. These two topics were
+  # only ever recorded to rosbags (no live subscriber), so dropping them costs
+  # only their presence in future bags. Re-enable only if the driver is patched
+  # to null-terminate stn_id (strnlen) -- see sensor_interfacing notes.
+  # - "LOG BESTGNSSPOSB ONTIME 0.1"
+  # - "LOG PPPPOSB ONTIME 1"
   - "LOG HEADING2B ONNEW"
   - "LOG PSRDOP2B ONCHANGED"
   - "LOG INSPVASB ONTIME 0.02"

--- a/src/interfacing/sensor_interfacing/launch/gps.launch.yaml
+++ b/src/interfacing/sensor_interfacing/launch/gps.launch.yaml
@@ -15,6 +15,10 @@ launch:
       default: "Oem7ReceiverTcp"
       description: "Interface type (Oem7ReceiverTcp or Oem7ReceiverUdp)"
 
+  - set_env:
+      name: "NOVATEL_OEM7_DRIVER_PARAM_OVERRIDES_PATH"
+      value: "$(find-pkg-share sensor_interfacing)/config/novatel_oem7_overrides.yaml"
+
   - include:
       file: "$(find-pkg-share novatel_oem7_driver)/launch/oem7_net.launch.py"
       arg:


### PR DESCRIPTION


### 📑  Description
Added the gps override config file to the launch file (for some reason it wasn't added before and defaulted to the config of the gps driver.

Additionally fixed the flakiness of the gps where sometimes it would start correctly, and other times it would crash. It seems there is a conflict between the GPS receiver's fixed-length, null-padded stn_id field into a std::string for the BESTGNSSPOS and PPPPOS messages and fastcdr (used by rmw_zenoh) aborts the whole node when it tries to serialize a string containing embedded null bytes, which is why the driver dies intermittently right after connecting.

The fix disables the two offending LOG commands, which are only recorded to rosbags and have no live subscribers.

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs

### 📝  Notes for reviewers
Should be tested with GPS fixes outside. I was only able to see IMU data while the car was inside.
