### PR TITLE
seperated topics for joystick idle

### DIFF
--- a/src/interfacing/ackermann_mux/DEVELOPING.md
+++ b/src/interfacing/ackermann_mux/DEVELOPING.md
@@ -46,7 +46,7 @@ ackermann_mux:
         topic: /joystick/ackermann
         priority: 200
         has_mask: true
-        mask_topic: /joystick/is_idle
+        mask_topic: /joystick/ackermann_is_idle
         safety_gating: true
       action:
         topic: /action/ackermann

--- a/src/interfacing/ackermann_mux/README.md
+++ b/src/interfacing/ackermann_mux/README.md
@@ -21,4 +21,4 @@ On each publish tick the node:
 
 **Safety gating** monitors command age on critical inputs (typically the joystick). If the joystick stops sending within `safety_threshold` seconds, the mux publishes the emergency command (brake) rather than holding the last known command.
 
-**Input masking** lets a source signal that it is voluntarily idle (e.g., `joystick/is_idle` when the enable trigger is released) so lower-priority inputs can take over without triggering a safety trip.
+**Input masking** lets a source signal that it is voluntarily idle (e.g., `joystick/ackermann_is_idle` when the enable trigger is released) so lower-priority inputs can take over without triggering a safety trip.

--- a/src/interfacing/ackermann_mux/config/ackermann_mux_config.yaml
+++ b/src/interfacing/ackermann_mux/config/ackermann_mux_config.yaml
@@ -14,7 +14,7 @@
         topic: joystick/ackermann
         priority: 100
         has_mask: true
-        mask_topic: joystick/is_idle
+        mask_topic: joystick/ackermann_is_idle
         safety_gating: true
 
       action:

--- a/src/interfacing/interfacing_bringup/config/bag_recorder/all_sensors.yaml
+++ b/src/interfacing/interfacing_bringup/config/bag_recorder/all_sensors.yaml
@@ -78,7 +78,7 @@ bag_recorder:
         - /interfacing/joy
         - /interfacing/joy/set_feedback
         - /interfacing/joystick/ackermann
-        - /interfacing/joystick/is_idle
+        - /interfacing/joystick/ackermann_is_idle
         - /interfacing/joystick/state
         - /interfacing/joystick_node/transition_event
         - /interfacing/oscc_interfacing/is_armed

--- a/src/interfacing/interfacing_bringup/config/bag_recorder/all_sensors_compressed.yaml
+++ b/src/interfacing/interfacing_bringup/config/bag_recorder/all_sensors_compressed.yaml
@@ -77,7 +77,7 @@ bag_recorder:
         - /interfacing/joy
         - /interfacing/joy/set_feedback
         - /interfacing/joystick/ackermann
-        - /interfacing/joystick/is_idle
+        - /interfacing/joystick/ackermann_is_idle
         - /interfacing/joystick/state
         - /interfacing/joystick_node/transition_event
         - /interfacing/oscc_interfacing/is_armed

--- a/src/interfacing/interfacing_bringup/config/bag_recorder/camera_compressed.yaml
+++ b/src/interfacing/interfacing_bringup/config/bag_recorder/camera_compressed.yaml
@@ -73,7 +73,7 @@ bag_recorder:
         - /interfacing/joy
         - /interfacing/joy/set_feedback
         - /interfacing/joystick/ackermann
-        - /interfacing/joystick/is_idle
+        - /interfacing/joystick/ackermann_is_idle
         - /interfacing/joystick/state
         - /interfacing/joystick_node/transition_event
         - /interfacing/oscc_interfacing/is_armed

--- a/src/interfacing/interfacing_bringup/config/bag_recorder/camera_only.yaml
+++ b/src/interfacing/interfacing_bringup/config/bag_recorder/camera_only.yaml
@@ -73,7 +73,7 @@ bag_recorder:
         - /interfacing/joy
         - /interfacing/joy/set_feedback
         - /interfacing/joystick/ackermann
-        - /interfacing/joystick/is_idle
+        - /interfacing/joystick/ackermann_is_idle
         - /interfacing/joystick/state
         - /interfacing/joystick_node/transition_event
         - /interfacing/oscc_interfacing/is_armed

--- a/src/interfacing/interfacing_bringup/config/bag_recorder/lidar_only.yaml
+++ b/src/interfacing/interfacing_bringup/config/bag_recorder/lidar_only.yaml
@@ -51,7 +51,7 @@ bag_recorder:
         - /interfacing/joy
         - /interfacing/joy/set_feedback
         - /interfacing/joystick/ackermann
-        - /interfacing/joystick/is_idle
+        - /interfacing/joystick/ackermann_is_idle
         - /interfacing/joystick/state
         - /interfacing/joystick_node/transition_event
         - /interfacing/oscc_interfacing/is_armed

--- a/src/interfacing/interfacing_bringup/config/interfacing.yaml
+++ b/src/interfacing/interfacing_bringup/config/interfacing.yaml
@@ -71,7 +71,7 @@
         topic: joystick/ackermann
         priority: 200
         has_mask: true
-        mask_topic: joystick/is_idle
+        mask_topic: joystick/ackermann_is_idle
         safety_gating: true
 
       action:

--- a/src/interfacing/interfacing_bringup/config/interfacing.yaml
+++ b/src/interfacing/interfacing_bringup/config/interfacing.yaml
@@ -190,7 +190,7 @@
         topic: joystick/roscco
         priority: 100
         has_mask: true
-        mask_topic: joystick/is_idle
+        mask_topic: joystick/roscco_is_idle
         safety_gating: false
 
       pid:

--- a/src/interfacing/joystick_interfacing/DEVELOPING.md
+++ b/src/interfacing/joystick_interfacing/DEVELOPING.md
@@ -15,7 +15,8 @@
 |-------|------|-------------|
 | `joystick/ackermann` | `ackermann_msgs/AckermannDriveStamped` | Ackermann commands (active in ACKERMANN mode) |
 | `roscco` | `roscco_msg/Roscco` | ROSCCO commands (active in ROSCCO mode) |
-| `joystick/is_idle` | `std_msgs/Bool` | `true` when enable axis is not pressed |
+| `joystick/ackermann_is_idle` | `std_msgs/Bool` | `true` when not actively providing Ackermann commands (ROSCCO mode or deadman released) |
+| `joystick/roscco_is_idle` | `std_msgs/Bool` | `true` when not actively providing ROSCCO commands (Ackermann mode or deadman released) |
 | `joystick/state` | `std_msgs/Int8` | Current mode: 0 = NULL, 1 = ACKERMANN, 2 = ROSCCO |
 | `joy/set_feedback` | `sensor_msgs/JoyFeedback` | Haptic rumble commands |
 
@@ -54,7 +55,7 @@ ros2 launch joystick_interfacing joystick_interfacing.launch.yaml
 
 **Enable axis:** The node checks `joy.axes[enable_axis]` on every joy message. If the value is > −0.9, the operator is considered not engaged and the node outputs zero commands. This threshold is designed for trigger axes that report +1.0 when unpressed and −1.0 when fully pressed.
 
-**Mode state machine:** Three states: `NULL` (no valid mode set), `ACKERMANN` (publishes on `joystick/ackermann`), `ROSCCO` (publishes on `roscco`). Pressing `toggle_button` cycles between ACKERMANN and ROSCCO. The haptic pulse count (1 pulse → ACKERMANN, 2 pulses → ROSCCO) confirms the new state.
+**Mode state machine:** Three states: `NULL` (no valid mode set), `ACKERMANN` (publishes on `joystick/ackermann`), `ROSCCO` (publishes on `joystick/roscco`). Pressing `toggle_button` cycles between ACKERMANN and ROSCCO — **only when the deadman is not held**. The haptic pulse count (1 pulse → ACKERMANN, 2 pulses → ROSCCO) confirms the new state. On toggle, a zero command is sent to both the old and new topic before switching, and each mux is notified via its respective idle topic.
 
 **Command scaling:** Stick axes (−1.0 to +1.0) are linearly scaled by `ackermann_max_steering_angle` and `ackermann_max_speed` (or their ROSCCO equivalents). The `invert_steering` / `invert_throttle` flags negate the axis value before scaling.
 
@@ -70,12 +71,12 @@ ros2 launch joystick_interfacing joystick_interfacing.launch.yaml
 
 ```bash
    ros2 topic echo /joystick/ackermann
-   ros2 topic echo /joystick/is_idle   # should be false while enable held
+   ros2 topic echo /joystick/ackermann_is_idle   # should be false while enable held
    ```
 
 1. **Release enable trigger** — `is_idle` should go `true` and commands should go to zero.
 
-2. **Test mode toggle** — press `toggle_button` (default: button 0). The joystick should vibrate (2 pulses → ROSCCO, 1 pulse → ACKERMANN) and `/joystick/state` should change value.
+2. **Test mode toggle** — **release the enable trigger first**, then press `toggle_button` (default: button 1 / B on Xbox). The joystick should vibrate (2 pulses → ROSCCO, 1 pulse → ACKERMANN) and `/joystick/state` should change value. Toggling while the deadman is held is intentionally ignored.
 
 3. **Test arming** — press `arming_button`. The node calls `/oscc_interfacing/arm`. If OSCC is running, expect 2 vibration pulses on success.
 
@@ -85,7 +86,7 @@ ros2 launch joystick_interfacing joystick_interfacing.launch.yaml
 |-------|----------|
 | Enable held, stick at max | `steering_angle` = `±ackermann_max_steering_angle` (default ±0.5 rad) |
 | Enable held, throttle at max | `speed` = `ackermann_max_speed` (default 2.0 m/s) |
-| Enable released | `speed = 0.0`, `steering_angle = 0.0`, `is_idle = true` |
+| Enable released | `speed = 0.0`, `steering_angle = 0.0`, `ackermann_is_idle = true`, `roscco_is_idle = true` |
 | Mode toggle to ROSCCO | `state = 2`, 2 vibration pulses |
 | Mode toggle to ACKERMANN | `state = 1`, 1 vibration pulse |
 | Arm success | 2 vibration pulses, `/oscc_interfacing/is_armed = true` |

--- a/src/interfacing/joystick_interfacing/README.md
+++ b/src/interfacing/joystick_interfacing/README.md
@@ -13,11 +13,12 @@ USB joystick
      │
 [joy_node] → /joy
      │
-[joystick_node] ──► /joystick/ackermann  → ackermann_mux (priority 200)
-                ──► /joystick/roscco      → oscc_mux     (priority 100)
-                ──► /joystick/is_idle     → mux masking
-                ──► /joy/set_feedback     → haptic rumble
-                ──► /oscc_interfacing/arm (service call)
+[joystick_node] ──► /joystick/ackermann         → ackermann_mux (priority 100)
+                ──► /joystick/roscco             → oscc_mux      (priority 100)
+                ──► /joystick/ackermann_is_idle  → ackermann_mux masking
+                ──► /joystick/roscco_is_idle     → oscc_mux masking
+                ──► /joy/set_feedback            → haptic rumble
+                ──► /oscc_interfacing/arm        (service call)
 ```
 
 ## Modes
@@ -27,7 +28,9 @@ The node operates in one of two modes at a time, toggled via `toggle_button`:
 - **ACKERMANN** — publishes to `/joystick/ackermann` with speed and steering angle limits
 - **ROSCCO** — publishes to `/joystick/roscco` with separate torque and speed limits
 
-The enable axis must be held (value ≤ −0.9) for commands to be non-zero. When released, the node publishes zero commands and sets `is_idle = true`, allowing lower-priority inputs in the mux to take over.
+The enable axis must be held (value ≤ −0.9) for commands to be non-zero. When released, the node publishes zero commands and sets both idle flags to `true`, allowing lower-priority inputs in the mux to take over.
+
+Mode switching is **blocked while the deadman is held** — release the enable trigger before pressing `toggle_button`. This prevents accidental pipeline switches mid-drive.
 
 ## Haptic Feedback Patterns
 

--- a/src/interfacing/joystick_interfacing/include/joystick_interfacing/joystick_interfacing.hpp
+++ b/src/interfacing/joystick_interfacing/include/joystick_interfacing/joystick_interfacing.hpp
@@ -107,7 +107,12 @@ private:
   /**
    * @brief Publish is idle state if no new input to joystick for a certain time
    */
-  void publish_idle_state(bool is_idle);
+  void publish_ackermann_idle_state(bool is_idle);
+
+  /**
+   * @brief Publish idle state for the ROSCCO mux (true = joystick not providing ROSCCO commands).
+   */
+  void publish_roscco_idle_state(bool is_idle);
 
   /**
    * @brief Publishes the current joystick state.
@@ -141,6 +146,7 @@ private:
   rclcpp::Publisher<ackermann_msgs::msg::AckermannDriveStamped>::SharedPtr ackermann_drive_stamped_pub_;
   rclcpp::Publisher<roscco_msg::msg::Roscco>::SharedPtr roscco_joystick_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr idle_state_pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr roscco_idle_state_pub_;
   // state status
   rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr state_pub_;
   rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr joy_feedback_pub_;

--- a/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
+++ b/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
@@ -393,7 +393,7 @@ void JoystickNode::joy_callback(const sensor_msgs::msg::Joy::ConstSharedPtr msg)
   }
 
   publish_state(use_roscco_topic_ ? JoystickNode::JoystickState::ROSSCO : JoystickNode::JoystickState::ACKERMANN);
-  publish_ackermann_idle_state(use_roscco_topic_);        // ackermann mux: idle when in ROSCCO mode
+  publish_ackermann_idle_state(use_roscco_topic_);  // ackermann mux: idle when in ROSCCO mode
   publish_roscco_idle_state(!use_roscco_topic_);  // oscc mux: idle when in Ackermann mode
 }
 

--- a/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
+++ b/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
@@ -75,7 +75,7 @@ JoystickNode::CallbackReturn JoystickNode::on_configure(const rclcpp_lifecycle::
   ackermann_drive_stamped_pub_ =
     this->create_publisher<ackermann_msgs::msg::AckermannDriveStamped>("joystick/ackermann", rclcpp::QoS(10));
   roscco_joystick_pub_ = this->create_publisher<roscco_msg::msg::Roscco>("roscco", rclcpp::QoS(10));
-  idle_state_pub_ = this->create_publisher<std_msgs::msg::Bool>("joystick/is_idle", rclcpp::QoS(10));
+  idle_state_pub_ = this->create_publisher<std_msgs::msg::Bool>("joystick/ackermann_is_idle", rclcpp::QoS(10));
   roscco_idle_state_pub_ = this->create_publisher<std_msgs::msg::Bool>("joystick/roscco_is_idle", rclcpp::QoS(10));
   state_pub_ = this->create_publisher<std_msgs::msg::Int8>("joystick/state", rclcpp::QoS(10));
   joy_feedback_pub_ = this->create_publisher<sensor_msgs::msg::JoyFeedback>("joy/set_feedback", rclcpp::QoS(10));

--- a/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
+++ b/src/interfacing/joystick_interfacing/src/joystick_interfacing.cpp
@@ -76,6 +76,7 @@ JoystickNode::CallbackReturn JoystickNode::on_configure(const rclcpp_lifecycle::
     this->create_publisher<ackermann_msgs::msg::AckermannDriveStamped>("joystick/ackermann", rclcpp::QoS(10));
   roscco_joystick_pub_ = this->create_publisher<roscco_msg::msg::Roscco>("roscco", rclcpp::QoS(10));
   idle_state_pub_ = this->create_publisher<std_msgs::msg::Bool>("joystick/is_idle", rclcpp::QoS(10));
+  roscco_idle_state_pub_ = this->create_publisher<std_msgs::msg::Bool>("joystick/roscco_is_idle", rclcpp::QoS(10));
   state_pub_ = this->create_publisher<std_msgs::msg::Int8>("joystick/state", rclcpp::QoS(10));
   joy_feedback_pub_ = this->create_publisher<sensor_msgs::msg::JoyFeedback>("joy/set_feedback", rclcpp::QoS(10));
 
@@ -133,6 +134,7 @@ JoystickNode::CallbackReturn JoystickNode::on_cleanup(const rclcpp_lifecycle::St
   ackermann_drive_stamped_pub_.reset();
   roscco_joystick_pub_.reset();
   idle_state_pub_.reset();
+  roscco_idle_state_pub_.reset();
   state_pub_.reset();
   joy_feedback_pub_.reset();
   is_armed_sub_.reset();
@@ -164,6 +166,7 @@ JoystickNode::CallbackReturn JoystickNode::on_shutdown(const rclcpp_lifecycle::S
   ackermann_drive_stamped_pub_.reset();
   roscco_joystick_pub_.reset();
   idle_state_pub_.reset();
+  roscco_idle_state_pub_.reset();
   state_pub_.reset();
   joy_feedback_pub_.reset();
   is_armed_sub_.reset();
@@ -190,16 +193,24 @@ bool JoystickNode::get_button(const sensor_msgs::msg::Joy & msg, int button_inde
 
 void JoystickNode::publish_neutral_state(bool is_idle)
 {
-  publish_idle_state(is_idle);
+  publish_ackermann_idle_state(is_idle);
+  publish_roscco_idle_state(true);  // not providing ROSCCO commands when neutral
   publish_state(JoystickState::NULL_STATE);
   publish_zero_command();
 }
 
-void JoystickNode::publish_idle_state(bool is_idle)
+void JoystickNode::publish_ackermann_idle_state(bool is_idle)
 {
   std_msgs::msg::Bool msg;
   msg.data = is_idle;
   idle_state_pub_->publish(msg);
+}
+
+void JoystickNode::publish_roscco_idle_state(bool is_idle)
+{
+  std_msgs::msg::Bool msg;
+  msg.data = is_idle;
+  roscco_idle_state_pub_->publish(msg);
 }
 
 void JoystickNode::publish_state(JoystickState state)
@@ -282,16 +293,22 @@ void JoystickNode::vibration_timer_callback()
 
 void JoystickNode::joy_callback(const sensor_msgs::msg::Joy::ConstSharedPtr msg)
 {
-  // Toggle logic (rising edge)
-  const bool toggle_button_pressed = get_button(*msg, toggle_button_);
-  if (toggle_button_pressed && !prev_toggle_button_pressed_) {
-    // Send zero to the current topic before switching to avoid stale commands
-    publish_zero_command();
+  const bool enable_pressed = get_axis(*msg, enable_axis_) <= -0.9;
 
+  // Toggle logic (rising edge) — blocked while deadman is held
+  const bool toggle_button_pressed = get_button(*msg, toggle_button_);
+  if (toggle_button_pressed && !prev_toggle_button_pressed_ && !enable_pressed) {
+    publish_zero_command();  // zero old topic
     use_roscco_topic_ = !use_roscco_topic_;
+    publish_zero_command();  // zero new topic
     RCLCPP_INFO(
       this->get_logger(), "Toggled output topic to: %s", use_roscco_topic_ ? "joystick/roscco" : "joystick/ackermann");
     vibrate(use_roscco_topic_ ? 2 : 1, toggle_vibration_duration_ms_);
+    prev_toggle_button_pressed_ = toggle_button_pressed;
+    publish_state(use_roscco_topic_ ? JoystickNode::JoystickState::ROSSCO : JoystickNode::JoystickState::ACKERMANN);
+    publish_ackermann_idle_state(use_roscco_topic_);
+    publish_roscco_idle_state(!use_roscco_topic_);
+    return;
   }
   prev_toggle_button_pressed_ = toggle_button_pressed;
 
@@ -333,10 +350,7 @@ void JoystickNode::joy_callback(const sensor_msgs::msg::Joy::ConstSharedPtr msg)
   }
   prev_arming_button_pressed_ = arming_button_pressed;
 
-  // Safety gating
-  // enable must be held
-  const bool enable_pressed = get_axis(*msg, enable_axis_) <= -0.9;
-
+  // Safety gating — enable must be held
   // If enable is not held, fully disarm and stop.
   if (!enable_pressed) {
     RCLCPP_WARN_THROTTLE(
@@ -379,7 +393,8 @@ void JoystickNode::joy_callback(const sensor_msgs::msg::Joy::ConstSharedPtr msg)
   }
 
   publish_state(use_roscco_topic_ ? JoystickNode::JoystickState::ROSSCO : JoystickNode::JoystickState::ACKERMANN);
-  publish_idle_state(use_roscco_topic_);  // Idle w.r.t. ackermann mux when in roscco mode
+  publish_ackermann_idle_state(use_roscco_topic_);        // ackermann mux: idle when in ROSCCO mode
+  publish_roscco_idle_state(!use_roscco_topic_);  // oscc mux: idle when in Ackermann mode
 }
 
 }  // namespace joystick_node

--- a/src/interfacing/joystick_interfacing/test/joystick_interfacing_test.cpp
+++ b/src/interfacing/joystick_interfacing/test/joystick_interfacing_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE_METHOD(TestExecutorFixture, "Joystick Interfacing Operation", "[joysti
   // Output
   auto ack_sub = std::make_shared<SubscriberTestNode<AckermannDriveStamped>>("/joystick/ackermann", "ack_sub");
   auto roscco_sub = std::make_shared<SubscriberTestNode<RosccoMsg>>("/roscco", "roscco_sub");
-  auto idle_sub = std::make_shared<SubscriberTestNode<Bool>>("/joystick/is_idle", "idle_sub");
+  auto idle_sub = std::make_shared<SubscriberTestNode<Bool>>("/joystick/ackermann_is_idle", "idle_sub");
   auto state_sub = std::make_shared<SubscriberTestNode<Int8>>("/joystick/state", "state_sub");
   auto feedback_sub = std::make_shared<SubscriberTestNode<JoyFeedback>>("/joy/set_feedback", "feedback_sub");
   add_node(ack_sub);

--- a/src/interfacing/joystick_interfacing/test/joystick_interfacing_test.cpp
+++ b/src/interfacing/joystick_interfacing/test/joystick_interfacing_test.cpp
@@ -161,13 +161,13 @@ TEST_CASE_METHOD(TestExecutorFixture, "Joystick Interfacing Operation", "[joysti
       auto state_future = state_sub->expect_next_message();
       auto roscco_future = roscco_sub->expect_next_message();
       auto feedback_on_future = feedback_sub->expect_next_message();
-      send_joy(-1.0, 0.5, 0.5, true);  // Rising edge toggles to /joystick/roscco
+      send_joy(0.0, 0.5, 0.5, true);  // Toggle without deadman (blocked when deadman held)
 
       auto state_msg = state_future.get();
       REQUIRE(state_msg.data == static_cast<int8_t>(JoystickState::ROSSCO));
 
       auto roscco_msg = roscco_future.get();
-      REQUIRE(roscco_msg.forward == Catch::Approx(1.0));
+      REQUIRE(roscco_msg.forward == Catch::Approx(0.0));  // zero cmd sent on new topic at toggle time
 
       auto fb_on_msg = feedback_on_future.get();
       REQUIRE(fb_on_msg.intensity == Catch::Approx(0.5));
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(TestExecutorFixture, "Joystick Interfacing Operation", "[joysti
       auto state_future = state_sub->expect_next_message();
       auto ack_future = ack_sub->expect_next_message();
       auto feedback_on_future = feedback_sub->expect_next_message();
-      send_joy(-1.0, 0.0, 0.0, true);
+      send_joy(0.0, 0.0, 0.0, true);  // Toggle without deadman (blocked when deadman held)
 
       auto state_msg = state_future.get();
       REQUIRE(state_msg.data == static_cast<int8_t>(JoystickState::ACKERMANN));

--- a/src/interfacing/oscc_mux/DEVELOPING.md
+++ b/src/interfacing/oscc_mux/DEVELOPING.md
@@ -46,7 +46,7 @@ oscc_mux:
         topic: /joystick/roscco
         priority: 100
         has_mask: true
-        mask_topic: /joystick/is_idle
+        mask_topic: /joystick/ackermann_is_idle
         safety_gating: false   # joystick may be silent when in Ackermann mode
       pid:
         topic: /pid/roscco


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
the root cause of the issue is: the 2 muxes share the same topic for idling. When deadman is pressed (idle = false) and switch to roscco, idle will always be set to true, so no joystick cmd could be processed. The fix is to have 2 topics with same logic to handle ackermann and roscco, while disabling mux switch when deadman is pressed for safety.

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs
Fixes #457 

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
