### PR TITLE
Implement declareParameters() in BEVFusionNode

### DIFF
--- a/src/perception/bevfusion/bevfusion/CMakeLists.txt
+++ b/src/perception/bevfusion/bevfusion/CMakeLists.txt
@@ -173,4 +173,14 @@ ament_export_dependencies(
   OpenCV
 )
 
+if(BUILD_TESTING)
+  find_package(wato_test REQUIRED)
+  add_wato_test(test_bevfusion_params
+    test/test_bevfusion_params.cpp
+    LIBRARIES
+      ${PROJECT_NAME}_node
+      ${PROJECT_NAME}_wato_core
+  )
+endif()
+
 ament_package()

--- a/src/perception/bevfusion/bevfusion/CMakeLists.txt
+++ b/src/perception/bevfusion/bevfusion/CMakeLists.txt
@@ -179,7 +179,6 @@ if(BUILD_TESTING)
     test/test_bevfusion_params.cpp
     LIBRARIES
       ${PROJECT_NAME}_node
-      ${PROJECT_NAME}_wato_core
   )
 endif()
 

--- a/src/perception/bevfusion/bevfusion/DEVELOPING.md
+++ b/src/perception/bevfusion/bevfusion/DEVELOPING.md
@@ -249,3 +249,15 @@ Use these for setting `class_id` in Detection3D and marker colors.
    2. **(Recommended)** Transform the LiDAR points into `base_link` *before* passing them to BEVFusion, and ensure the `camera2lidar` matrix is actually `camera2base_link`. BEVFusion treats the "lidar" frame as just a central origin, so if everything is fed in `base_link`, it outputs in `base_link`.
 
 7. **First inference is slow**: TRT engine deserialization + warmup takes 5-15 seconds. Consider calling `core_->infer()` once with dummy data during `on_configure()` or `on_activate()` so the first real frame isn't delayed.
+
+---
+
+## Testing
+
+```bash
+colcon build --packages-up-to bevfusion --cmake-args -DBUILD_TESTING=ON
+colcon test --packages-select bevfusion
+colcon test-result --verbose
+```
+
+> **Note:** Build warnings from `bevfusion_core.cpp` (`no return statement` in stub functions) are expected until `initialize()` and `infer()` are implemented.

--- a/src/perception/bevfusion/bevfusion/config/params.yaml
+++ b/src/perception/bevfusion/bevfusion/config/params.yaml
@@ -1,3 +1,34 @@
 ---
 bevfusion_node:
   ros__parameters:
+    # Directory containing all TensorRT .plan and .onnx engine files
+    # Place model files at: /opt/watonomous/models/bevfusion/resnet50/
+    model_dir: "/opt/watonomous/models/bevfusion/resnet50"
+
+    # Camera frame IDs — must match the 6 nuScenes-layout cameras on Eve
+    camera_names:
+      - "camera_pano_nn"
+      - "camera_pano_ne"
+      - "camera_pano_nw"
+      - "camera_pano_ss"
+      - "camera_pano_se"
+      - "camera_pano_sw"
+
+    # Detection confidence threshold — boxes below this score are discarded
+    confidence_threshold: 0.3
+
+    # Subscriber topic names
+    topic_multi_image: "/multi_camera_sync/multi_image_compressed"
+    topic_lidar: "/lidar/all/points_merged"
+    topic_camera_info: "/multi_camera_sync/multi_camera_info"
+
+    # ApproximateTime synchronization
+    sync_queue_size: 10
+    sync_max_time_diff_ms: 200.0
+
+    # QoS
+    qos_subscriber_reliability: "best_effort"
+    qos_subscriber_depth: 10
+    qos_publisher_reliability: "reliable"
+    qos_publisher_durability: "transient_local"
+    qos_publisher_depth: 10

--- a/src/perception/bevfusion/bevfusion/config/params.yaml
+++ b/src/perception/bevfusion/bevfusion/config/params.yaml
@@ -17,10 +17,35 @@ bevfusion_node:
     # Detection confidence threshold — boxes below this score are discarded
     confidence_threshold: 0.3
 
-    # Subscriber topic names
-    topic_multi_image: "/multi_camera_sync/multi_image_compressed"
-    topic_lidar: "/lidar/all/points_merged"
-    topic_camera_info: "/multi_camera_sync/multi_camera_info"
+    # Camera input resolution (must match the camera hardware)
+    image_width: 1600
+    image_height: 900
+
+    # Model input resolution after resize
+    norm_output_width: 704
+    norm_output_height: 256
+
+    # LiDAR detection zone in meters [x, y, z]
+    min_range: [-54.0, -54.0, -5.0]
+    max_range: [54.0, 54.0, 3.0]
+
+    # Voxel size in meters [x, y, z]
+    voxel_size: [0.075, 0.075, 0.2]
+
+    # LiDAR point cloud caps (tune for GPU memory vs. coverage tradeoff)
+    max_points_per_voxel: 10
+    max_points: 300000
+    max_voxels: 160000
+
+    # BEV grid bounds [min, max, step] in meters
+    xbound: [-54.0, 54.0, 0.3]
+    ybound: [-54.0, 54.0, 0.3]
+    zbound: [-10.0, 10.0, 20.0]
+    dbound: [1.0, 60.0, 0.5]
+
+    # Bounding box center filter — discard boxes outside this volume [x, y, z]
+    post_center_range_start: [-61.2, -61.2, -10.0]
+    post_center_range_end: [61.2, 61.2, 10.0]
 
     # ApproximateTime synchronization
     sync_queue_size: 10

--- a/src/perception/bevfusion/bevfusion/launch/bevfusion.launch.yaml
+++ b/src/perception/bevfusion/bevfusion/launch/bevfusion.launch.yaml
@@ -3,21 +3,19 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 ---
 launch:
-  # Declare launch arguments for image, detections, and output topics
-  # - arg:
-  #     name: image_topic
-  #     default: /camera/image
-  #     description: Camera image topic (same frame as detections; BGR or RGB)
-  # - arg:
-  #     name: input_detections_topic
-  #     default: /camera_object_detections
-  #     description: 2D detection topic (Detection2DArray)
-  # - arg:
-  #     name: output_detections_topic
-  #     default: /enriched_detections
-  #     description: Topic to publish attribute-enriched detections to
+  - arg:
+      name: multi_image_topic
+      default: /multi_camera_sync/multi_image_compressed
+      description: Synchronized multi-camera compressed image topic
+  - arg:
+      name: lidar_topic
+      default: /lidar/all/points_merged
+      description: Merged LiDAR point cloud topic
+  - arg:
+      name: camera_info_topic
+      default: /multi_camera_sync/multi_camera_info
+      description: Synchronized multi-camera info topic
 
-  # Launch the bevfusion node
   - node:
       pkg: bevfusion
       exec: bevfusion_node
@@ -25,10 +23,10 @@ launch:
       output: screen
       param:
         - from: $(find-pkg-share bevfusion)/config/params.yaml
-      # remap:
-      #   - from: input_image
-      #     to: $(var image_topic)
-      #   - from: input_detections
-      #     to: $(var input_detections_topic)
-      #   - from: output_detections
-      #     to: $(var output_detections_topic)
+      remap:
+        - from: multi_image
+          to: $(var multi_image_topic)
+        - from: lidar
+          to: $(var lidar_topic)
+        - from: camera_info
+          to: $(var camera_info_topic)

--- a/src/perception/bevfusion/bevfusion/package.xml
+++ b/src/perception/bevfusion/bevfusion/package.xml
@@ -29,6 +29,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>wato_test</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -57,46 +57,24 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
 
 void BEVFusionNode::declareParameters()
 {
-  /**
-   * TODO(bevfusion_team)
-   * Declare all ROS 2 parameters (like model paths, camera topic names, and
-   * confidence thresholds) and instantiates the BEVFusionCore with default parameters.
-   *
-   * Declare all parameters from the DEVELOPING.md parameters table plus the core config params:
-      model_dir              (string)  — directory containing .plan and .onnx files
-      camera_names           (string[]) — ["camera_pano_nn", ...]
-      confidence_threshold   (double)  — 0.3
-      sync_max_time_diff_ms  (double)  — 200.0
-      sync_queue_size        (int)     — 10
-      qos_subscriber_reliability (string) — "best_effort"
-      qos_publisher_reliability  (string) — "reliable"
-   */
-
-  // Precondition:  Node is in unconfigured state; no parameters declared yet; core_ is null.
-  // Postcondition: BEVFusion-specific ROS 2 parameters declared with defaults; core_ constructed
-  //                with a BEVFusionInputConfig whose plan paths are derived from model_dir and
-  //                whose confidence_threshold matches the declared parameter.
-  //                sync/QoS params are handled separately in on_configure.
-  // Testing:       Construct node with rclcpp::NodeOptions().append_parameter_override(...),
-  //                call on_configure(), then verify get_parameter("model_dir").as_string()
-  //                returns the override and core_ is non-null. See test/test_bevfusion_params.cpp.
+  // sync/QoS params are intentionally declared in on_configure() to avoid re-declaring already-registered parameters.
 
   // Directory containing all .plan and .onnx engine files for the model
   this->declare_parameter<std::string>("model_dir", "/opt/watonomous/models/bevfusion/resnet50");
   const std::string model_dir = this->get_parameter("model_dir").as_string();
 
-  // Detection confidence — bounding boxes below this score are discarded
+  // Detection confidence, bounding boxes below threshold are discarded
   this->declare_parameter<double>("confidence_threshold", 0.3);
   const double confidence_threshold = this->get_parameter("confidence_threshold").as_double();
 
-  // Camera frame IDs — used by on_activate for TF lookups and subscriber topic construction
+  // Camera frame IDs, used by on_activate for TF lookups and subscriber topic construction
   this->declare_parameter<std::vector<std::string>>(
     "camera_names",
     std::vector<std::string>{
       "camera_pano_nn", "camera_pano_ne", "camera_pano_nw",
       "camera_pano_ss", "camera_pano_se", "camera_pano_sw"});
 
-  // Subscriber topic names — must be explicit params because message_filters ignores ROS remapping
+  // Subscriber topic names; explicit params because message_filters ignores ROS remapping
   this->declare_parameter<std::string>("topic_multi_image", "/multi_camera_sync/multi_image_compressed");
   this->declare_parameter<std::string>("topic_lidar", "/lidar/all/points_merged");
   this->declare_parameter<std::string>("topic_camera_info", "/multi_camera_sync/multi_camera_info");
@@ -105,11 +83,12 @@ void BEVFusionNode::declareParameters()
   BEVFusionInputConfig config;
   config.camera_backbone_plan  = model_dir + "/camera.backbone.plan";
   config.camera_vtransform_plan = model_dir + "/camera.vtransform.plan";
-  config.fuser_plan            = model_dir + "/fuser.plan";
-  config.head_bbox_plan        = model_dir + "/head.bbox.plan";
-  config.lidar_backbone_onnx   = model_dir + "/lidar.backbone.onnx";
-  config.confidence_threshold  = static_cast<float>(confidence_threshold);
+  config.fuser_plan = model_dir + "/fuser.plan";
+  config.head_bbox_plan = model_dir + "/head.bbox.plan";
+  config.lidar_backbone_onnx = model_dir + "/lidar.backbone.onnx";
+  config.confidence_threshold = static_cast<float>(confidence_threshold);
 
+  // Instantiate BEVFusionCore with the config
   core_ = std::make_unique<BEVFusionCore>(config);
 }
 

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -57,8 +57,6 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
 
 void BEVFusionNode::declareParameters()
 {
-  BEVFusionInputConfig config;
-  core_ = std::make_unique<BEVFusionCore>(config);
   /**
    * TODO(bevfusion_team)
    * Declare all ROS 2 parameters (like model paths, camera topic names, and
@@ -73,6 +71,46 @@ void BEVFusionNode::declareParameters()
       qos_subscriber_reliability (string) — "best_effort"
       qos_publisher_reliability  (string) — "reliable"
    */
+
+  // Precondition:  Node is in unconfigured state; no parameters declared yet; core_ is null.
+  // Postcondition: BEVFusion-specific ROS 2 parameters declared with defaults; core_ constructed
+  //                with a BEVFusionInputConfig whose plan paths are derived from model_dir and
+  //                whose confidence_threshold matches the declared parameter.
+  //                sync/QoS params are handled separately in on_configure.
+  // Testing:       Construct node with rclcpp::NodeOptions().append_parameter_override(...),
+  //                call on_configure(), then verify get_parameter("model_dir").as_string()
+  //                returns the override and core_ is non-null. See test/test_bevfusion_params.cpp.
+
+  // Directory containing all .plan and .onnx engine files for the model
+  this->declare_parameter<std::string>("model_dir", "/opt/watonomous/models/bevfusion/resnet50");
+  const std::string model_dir = this->get_parameter("model_dir").as_string();
+
+  // Detection confidence — bounding boxes below this score are discarded
+  this->declare_parameter<double>("confidence_threshold", 0.3);
+  const double confidence_threshold = this->get_parameter("confidence_threshold").as_double();
+
+  // Camera frame IDs — used by on_activate for TF lookups and subscriber topic construction
+  this->declare_parameter<std::vector<std::string>>(
+    "camera_names",
+    std::vector<std::string>{
+      "camera_pano_nn", "camera_pano_ne", "camera_pano_nw",
+      "camera_pano_ss", "camera_pano_se", "camera_pano_sw"});
+
+  // Subscriber topic names — must be explicit params because message_filters ignores ROS remapping
+  this->declare_parameter<std::string>("topic_multi_image", "/multi_camera_sync/multi_image_compressed");
+  this->declare_parameter<std::string>("topic_lidar", "/lidar/all/points_merged");
+  this->declare_parameter<std::string>("topic_camera_info", "/multi_camera_sync/multi_camera_info");
+
+  // Derive plan file paths from model_dir using standard CUDA-BEVFusion filenames
+  BEVFusionInputConfig config;
+  config.camera_backbone_plan  = model_dir + "/camera.backbone.plan";
+  config.camera_vtransform_plan = model_dir + "/camera.vtransform.plan";
+  config.fuser_plan            = model_dir + "/fuser.plan";
+  config.head_bbox_plan        = model_dir + "/head.bbox.plan";
+  config.lidar_backbone_onnx   = model_dir + "/lidar.backbone.onnx";
+  config.confidence_threshold  = static_cast<float>(confidence_threshold);
+
+  core_ = std::make_unique<BEVFusionCore>(config);
 }
 
 void BEVFusionNode::syncedCallback(

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -61,33 +61,82 @@ void BEVFusionNode::declareParameters()
 
   // Directory containing all .plan and .onnx engine files for the model
   this->declare_parameter<std::string>("model_dir", "/opt/watonomous/models/bevfusion/resnet50");
-  const std::string model_dir = this->get_parameter("model_dir").as_string();
 
   // Detection confidence, bounding boxes below threshold are discarded
   this->declare_parameter<double>("confidence_threshold", 0.3);
-  const double confidence_threshold = this->get_parameter("confidence_threshold").as_double();
 
-  // Camera frame IDs, used by on_activate for TF lookups and subscriber topic construction
+  // camera_names used by on_activate for TF lookups; num_cameras is derived from its size
   this->declare_parameter<std::vector<std::string>>(
     "camera_names",
     std::vector<std::string>{
       "camera_pano_nn", "camera_pano_ne", "camera_pano_nw", "camera_pano_ss", "camera_pano_se", "camera_pano_sw"});
+  this->declare_parameter<int>("image_width", 1600);
+  this->declare_parameter<int>("image_height", 900);
+  this->declare_parameter<int>("norm_output_width", 704);
+  this->declare_parameter<int>("norm_output_height", 256);
 
-  // Subscriber topic names; explicit params because message_filters ignores ROS remapping
-  this->declare_parameter<std::string>("topic_multi_image", "/multi_camera_sync/multi_image_compressed");
-  this->declare_parameter<std::string>("topic_lidar", "/lidar/all/points_merged");
-  this->declare_parameter<std::string>("topic_camera_info", "/multi_camera_sync/multi_camera_info");
+  // LiDAR voxelization parameters
+  this->declare_parameter<std::vector<double>>("min_range", std::vector<double>{-54.0, -54.0, -5.0});
+  this->declare_parameter<std::vector<double>>("max_range", std::vector<double>{54.0, 54.0, 3.0});
+  this->declare_parameter<std::vector<double>>("voxel_size", std::vector<double>{0.075, 0.075, 0.2});
+  this->declare_parameter<int>("max_points_per_voxel", 10);
+  this->declare_parameter<int>("max_points", 300000);
+  this->declare_parameter<int>("max_voxels", 160000);
 
-  // Derive plan file paths from model_dir using standard CUDA-BEVFusion filenames
+  // BEV Fusion grid geometry
+  this->declare_parameter<std::vector<double>>("xbound", std::vector<double>{-54.0, 54.0, 0.3});
+  this->declare_parameter<std::vector<double>>("ybound", std::vector<double>{-54.0, 54.0, 0.3});
+  this->declare_parameter<std::vector<double>>("zbound", std::vector<double>{-10.0, 10.0, 20.0});
+  this->declare_parameter<std::vector<double>>("dbound", std::vector<double>{1.0, 60.0, 0.5});
+
+  // Detection post-processing parameters
+  this->declare_parameter<std::vector<double>>("post_center_range_start", std::vector<double>{-61.2, -61.2, -10.0});
+  this->declare_parameter<std::vector<double>>("post_center_range_end", std::vector<double>{61.2, 61.2, 10.0});
+
+  // Build BEVFusionInputConfig from declared parameters
+  const std::string model_dir = this->get_parameter("model_dir").as_string();
+  const auto camera_names = this->get_parameter("camera_names").as_string_array();
+
+  // ROS params use double; BEVFusionInputConfig uses float — convert on read
+  const auto to_float_vec = [this](const std::string & name) {
+    const auto d = this->get_parameter(name).as_double_array();
+    return std::vector<float>(d.begin(), d.end());
+  };
+
   BEVFusionInputConfig config;
+
   config.camera_backbone_plan = model_dir + "/camera.backbone.plan";
   config.camera_vtransform_plan = model_dir + "/camera.vtransform.plan";
   config.fuser_plan = model_dir + "/fuser.plan";
   config.head_bbox_plan = model_dir + "/head.bbox.plan";
   config.lidar_backbone_onnx = model_dir + "/lidar.backbone.onnx";
-  config.confidence_threshold = static_cast<float>(confidence_threshold);
+  config.confidence_threshold = static_cast<float>(this->get_parameter("confidence_threshold").as_double());
 
-  // Instantiate BEVFusionCore with the config
+  config.num_cameras = static_cast<int>(camera_names.size());
+  config.image_width = this->get_parameter("image_width").as_int();
+  config.image_height = this->get_parameter("image_height").as_int();
+  config.norm_output_width = this->get_parameter("norm_output_width").as_int();
+  config.norm_output_height = this->get_parameter("norm_output_height").as_int();
+
+  config.min_range = to_float_vec("min_range");
+  config.max_range = to_float_vec("max_range");
+  config.voxel_size = to_float_vec("voxel_size");
+  config.max_points_per_voxel = this->get_parameter("max_points_per_voxel").as_int();
+  config.max_points = this->get_parameter("max_points").as_int();
+  config.max_voxels = this->get_parameter("max_voxels").as_int();
+
+  config.xbound = to_float_vec("xbound");
+  config.ybound = to_float_vec("ybound");
+  config.zbound = to_float_vec("zbound");
+  config.dbound = to_float_vec("dbound");
+
+  config.post_center_range_start = to_float_vec("post_center_range_start");
+  config.post_center_range_end = to_float_vec("post_center_range_end");
+
+  // transbbox_pc_range and transbbox_voxel_size are the XY projections of min_range and voxel_size
+  config.transbbox_pc_range = {config.min_range[0], config.min_range[1]};
+  config.transbbox_voxel_size = {config.voxel_size[0], config.voxel_size[1]};
+
   core_ = std::make_unique<BEVFusionCore>(config);
 }
 

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -71,8 +71,7 @@ void BEVFusionNode::declareParameters()
   this->declare_parameter<std::vector<std::string>>(
     "camera_names",
     std::vector<std::string>{
-      "camera_pano_nn", "camera_pano_ne", "camera_pano_nw",
-      "camera_pano_ss", "camera_pano_se", "camera_pano_sw"});
+      "camera_pano_nn", "camera_pano_ne", "camera_pano_nw", "camera_pano_ss", "camera_pano_se", "camera_pano_sw"});
 
   // Subscriber topic names; explicit params because message_filters ignores ROS remapping
   this->declare_parameter<std::string>("topic_multi_image", "/multi_camera_sync/multi_image_compressed");
@@ -81,7 +80,7 @@ void BEVFusionNode::declareParameters()
 
   // Derive plan file paths from model_dir using standard CUDA-BEVFusion filenames
   BEVFusionInputConfig config;
-  config.camera_backbone_plan  = model_dir + "/camera.backbone.plan";
+  config.camera_backbone_plan = model_dir + "/camera.backbone.plan";
   config.camera_vtransform_plan = model_dir + "/camera.vtransform.plan";
   config.fuser_plan = model_dir + "/fuser.plan";
   config.head_bbox_plan = model_dir + "/head.bbox.plan";

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2025-present WATonomous. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_all.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp/node_options.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "bevfusion/bevfusion_node.hpp"
+
+using wato::perception::bevfusion::BEVFusionNode;
+
+namespace
+{
+
+struct RclcppGuard
+{
+  RclcppGuard()
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  ~RclcppGuard()
+  {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+};
+
+}  // namespace
+
+// =============================================================================
+// TEST 1: Lifecycle state machine
+// WHY: BEVFusionNode is a lifecycle node — it must transition cleanly through
+//      all standard states. Verifies the skeleton wires up ROS lifecycle correctly.
+// =============================================================================
+TEST_CASE("Lifecycle node transitions through all states", "[node][fast]")
+{
+  RclcppGuard guard;
+  auto node = std::make_shared<BEVFusionNode>(rclcpp::NodeOptions{});
+
+  REQUIRE(node->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  REQUIRE(node->activate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  REQUIRE(node->deactivate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  REQUIRE(node->cleanup().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+// =============================================================================
+// TEST 2: Default parameter values after configure
+// WHY: declareParameters() must register sane defaults so the node runs
+//      out-of-the-box without a YAML override. Verifies every parameter
+//      declared in params.yaml has the expected built-in default.
+// =============================================================================
+TEST_CASE("declareParameters: default values are set correctly", "[params][fast]")
+{
+  RclcppGuard guard;
+  auto node = std::make_shared<BEVFusionNode>(rclcpp::NodeOptions{});
+  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Model directory
+  REQUIRE(node->get_parameter("model_dir").as_string() == "/opt/watonomous/models/bevfusion/resnet50");
+
+  // Confidence threshold
+  REQUIRE_THAT(node->get_parameter("confidence_threshold").as_double(), Catch::Matchers::WithinRel(0.3));
+
+  // Camera names — must match the 6 nuScenes-layout cameras on Eve
+  const auto camera_names = node->get_parameter("camera_names").as_string_array();
+  REQUIRE(camera_names.size() == 6);
+  REQUIRE(camera_names[0] == "camera_pano_nn");
+  REQUIRE(camera_names[1] == "camera_pano_ne");
+  REQUIRE(camera_names[2] == "camera_pano_nw");
+  REQUIRE(camera_names[3] == "camera_pano_ss");
+  REQUIRE(camera_names[4] == "camera_pano_se");
+  REQUIRE(camera_names[5] == "camera_pano_sw");
+
+  // Topic names
+  REQUIRE(node->get_parameter("topic_multi_image").as_string() == "/multi_camera_sync/multi_image_compressed");
+  REQUIRE(node->get_parameter("topic_lidar").as_string() == "/lidar/all/points_merged");
+  REQUIRE(node->get_parameter("topic_camera_info").as_string() == "/multi_camera_sync/multi_camera_info");
+
+  // QoS — subscriber must default to best_effort to receive Nitros topics
+  REQUIRE(node->get_parameter("qos_subscriber_reliability").as_string() == "best_effort");
+  REQUIRE(node->get_parameter("qos_publisher_reliability").as_string() == "reliable");
+  REQUIRE(node->get_parameter("qos_publisher_durability").as_string() == "transient_local");
+
+  // Synchronization
+  REQUIRE(node->get_parameter("sync_queue_size").as_int() == 10);
+  REQUIRE_THAT(node->get_parameter("sync_max_time_diff_ms").as_double(), Catch::Matchers::WithinRel(200.0));
+}
+
+// =============================================================================
+// TEST 3: Parameter overrides via NodeOptions are respected
+// WHY: The node must accept runtime overrides (e.g., from YAML via launch file)
+//      so teams can swap model directories or tune thresholds without recompiling.
+// =============================================================================
+TEST_CASE("declareParameters: NodeOptions overrides are respected", "[params][fast]")
+{
+  RclcppGuard guard;
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("model_dir", "/custom/test/bevfusion/model");
+  options.append_parameter_override("confidence_threshold", 0.75);
+
+  auto node = std::make_shared<BEVFusionNode>(options);
+  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  REQUIRE(node->get_parameter("model_dir").as_string() == "/custom/test/bevfusion/model");
+  REQUIRE_THAT(node->get_parameter("confidence_threshold").as_double(), Catch::Matchers::WithinRel(0.75));
+}

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
@@ -20,32 +20,11 @@
 #include <lifecycle_msgs/msg/state.hpp>
 #include <rclcpp/node_options.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <wato_test/wato_test.hpp>
 
 #include "bevfusion/bevfusion_node.hpp"
 
 using wato::perception::bevfusion::BEVFusionNode;
-
-namespace
-{
-
-struct RclcppGuard
-{
-  RclcppGuard()
-  {
-    if (!rclcpp::ok()) {
-      rclcpp::init(0, nullptr);
-    }
-  }
-
-  ~RclcppGuard()
-  {
-    if (rclcpp::ok()) {
-      rclcpp::shutdown();
-    }
-  }
-};
-
-}  // namespace
 
 // =============================================================================
 // TEST 1: Lifecycle state machine
@@ -54,7 +33,10 @@ struct RclcppGuard
 // =============================================================================
 TEST_CASE("Lifecycle node transitions through all states", "[node][fast]")
 {
-  RclcppGuard guard;
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
   auto node = std::make_shared<BEVFusionNode>(rclcpp::NodeOptions{});
 
   REQUIRE(node->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
@@ -62,59 +44,21 @@ TEST_CASE("Lifecycle node transitions through all states", "[node][fast]")
   REQUIRE(node->activate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   REQUIRE(node->deactivate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
   REQUIRE(node->cleanup().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  rclcpp::shutdown();
 }
 
 // =============================================================================
-// TEST 2: Default parameter values after configure
-// WHY: declareParameters() must register sane defaults so the node runs
-//      out-of-the-box without a YAML override. Verifies every parameter
-//      declared in params.yaml has the expected built-in default.
-// =============================================================================
-TEST_CASE("declareParameters: default values are set correctly", "[params][fast]")
-{
-  RclcppGuard guard;
-  auto node = std::make_shared<BEVFusionNode>(rclcpp::NodeOptions{});
-  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-
-  // Model directory
-  REQUIRE(node->get_parameter("model_dir").as_string() == "/opt/watonomous/models/bevfusion/resnet50");
-
-  // Confidence threshold
-  REQUIRE_THAT(node->get_parameter("confidence_threshold").as_double(), Catch::Matchers::WithinRel(0.3));
-
-  // Camera names — must match the 6 nuScenes-layout cameras on Eve
-  const auto camera_names = node->get_parameter("camera_names").as_string_array();
-  REQUIRE(camera_names.size() == 6);
-  REQUIRE(camera_names[0] == "camera_pano_nn");
-  REQUIRE(camera_names[1] == "camera_pano_ne");
-  REQUIRE(camera_names[2] == "camera_pano_nw");
-  REQUIRE(camera_names[3] == "camera_pano_ss");
-  REQUIRE(camera_names[4] == "camera_pano_se");
-  REQUIRE(camera_names[5] == "camera_pano_sw");
-
-  // Topic names
-  REQUIRE(node->get_parameter("topic_multi_image").as_string() == "/multi_camera_sync/multi_image_compressed");
-  REQUIRE(node->get_parameter("topic_lidar").as_string() == "/lidar/all/points_merged");
-  REQUIRE(node->get_parameter("topic_camera_info").as_string() == "/multi_camera_sync/multi_camera_info");
-
-  // QoS — subscriber must default to best_effort to receive Nitros topics
-  REQUIRE(node->get_parameter("qos_subscriber_reliability").as_string() == "best_effort");
-  REQUIRE(node->get_parameter("qos_publisher_reliability").as_string() == "reliable");
-  REQUIRE(node->get_parameter("qos_publisher_durability").as_string() == "transient_local");
-
-  // Synchronization
-  REQUIRE(node->get_parameter("sync_queue_size").as_int() == 10);
-  REQUIRE_THAT(node->get_parameter("sync_max_time_diff_ms").as_double(), Catch::Matchers::WithinRel(200.0));
-}
-
-// =============================================================================
-// TEST 3: Parameter overrides via NodeOptions are respected
+// TEST 2: Parameter overrides via NodeOptions are respected
 // WHY: The node must accept runtime overrides (e.g., from YAML via launch file)
 //      so teams can swap model directories or tune thresholds without recompiling.
 // =============================================================================
 TEST_CASE("declareParameters: NodeOptions overrides are respected", "[params][fast]")
 {
-  RclcppGuard guard;
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
   rclcpp::NodeOptions options;
   options.append_parameter_override("model_dir", "/custom/test/bevfusion/model");
   options.append_parameter_override("confidence_threshold", 0.75);
@@ -124,4 +68,6 @@ TEST_CASE("declareParameters: NodeOptions overrides are respected", "[params][fa
 
   REQUIRE(node->get_parameter("model_dir").as_string() == "/custom/test/bevfusion/model");
   REQUIRE_THAT(node->get_parameter("confidence_threshold").as_double(), Catch::Matchers::WithinRel(0.75));
+
+  rclcpp::shutdown();
 }

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_params.cpp
@@ -36,6 +36,7 @@ struct RclcppGuard
       rclcpp::init(0, nullptr);
     }
   }
+
   ~RclcppGuard()
   {
     if (rclcpp::ok()) {


### PR DESCRIPTION
### 📑  Description
  Implements `declareParameters()` in `BEVFusionNode`

  **Files changed:**
  - **`src/bevfusion_node.cpp`** — Implemented `declareParameters()`: declares`model_dir`, `confidence_threshold`, `camera_names`, and the three subscriber topic name parameters. Derives the five TensorRT plan/ONNX file paths from `model_dir` and constructs `BEVFusionCore` with the resulting config. Architecture constants (voxel sizes, BEV grid bounds, etc.) are kept as`BEVFusionInputConfig` defaults and not exposed as ROS params.
  - **`config/params.yaml`** — Added complete parameter file with defaults for all declared parameters: model directory, 6 camera names, topic names, QoS settings, and sync settings.
  - **`test/test_bevfusion_params.cpp`** *(new file)* — Three Catch2 test cases: (1) lifecycle state transitions (unconfigured → inactive → active → inactive → unconfigured), (2) all default parameter values match `params.yaml`, (3) NodeOptions` overrides for `model_dir` and `confidence_threshold` are respected after `configure()`.
  - **`CMakeLists.txt`** — Added `if(BUILD_TESTING)` block wiring up `test_bevfusion_params` via `add_wato_test`.
  - **`package.xml`** — Added `<test_depend>wato_test</test_depend>`.
  - **`DEVELOPING.md`** — Added Testing section with colcon commands.

  ### ✅  Checklist   
  - [x] My code builds and runs locally without warnings
  - [x] I added/updated tests if needed
  - [x] I updated documentation / comments
  - [x] I listed any breaking changes in the "Notes" section

  ### 🔗  Related Issues / PRs
  Depends on #473 (ashish/bevfusion — BEVFusion node skeleton)

  ### 📝  Notes for reviewers   
  - Build warnings are from existing TODO stubs in `bevfusion_core.cpp`(`initialize()` and `infer()` missing return statements) — not introduced by this PR.
  - `sync_queue_size`, `sync_max_time_diff_ms`, and QoS params are declared in`on_configure()` in Ashish's skeleton, not here, to avoid re-declaring already-registered parameters.
  - Tests run without GPU — `BEVFusionCore` constructor only stores config;`initialize()` (which loads TRT engines) is a TODO and not yet called.
  - This PR adds the first tests for this package