### PR TITLE
Implement bevfusion core infer()

### DIFF
--- a/src/perception/bevfusion/DEVELOPING.md
+++ b/src/perception/bevfusion/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**BEVFusion** is a ROS 2 lifecycle composable node that fuses camera and LiDAR data into a unified Bird's-Eye View (BEV) representation for 3D object detection and map segmentation.
+**BEVFusion** is a ROS 2 lifecycle composable node that fuses camera and LiDAR data into a unified Bird's-Eye View (BEV) representation for 3D object detection. *(Note: Map segmentation is supported by the architecture but not currently implemented in the CUDA-BEVFusion C++ wrapper).*
 
 Rather than forcing cameras to see in 3D or LiDAR to see in 2D, both are converted into a top-down BEV grid where they are fused and processed together. This maintains both geometric structure and semantic density, and compensates for individual sensor weaknesses — cameras struggle in low light, LiDAR struggles in poor weather.
 
@@ -124,6 +124,7 @@ Inference uses TensorRT with FP16 precision. INT8 is deferred — it requires ca
 
 ### What BEVFusion does NOT do
 
+- **Map Segmentation** — while the BEVFusion architecture supports it, this C++ TensorRT wrapper is currently only implemented for 3D object detection (bounding boxes).
 - **Floor removal** — the model's encoder learns to ignore the road internally
 - **Clustering** — would discard geometry the model needs
 - **Tracking** — handled by the `tracking` node downstream

--- a/src/perception/bevfusion/bevfusion/DEVELOPING.md
+++ b/src/perception/bevfusion/bevfusion/DEVELOPING.md
@@ -259,5 +259,3 @@ colcon build --packages-up-to bevfusion --cmake-args -DBUILD_TESTING=ON
 colcon test --packages-select bevfusion
 colcon test-result --verbose
 ```
-
-> **Note:** Build warnings from `bevfusion_core.cpp` (`no return statement` in stub functions) are expected until `initialize()` and `infer()` are implemented.

--- a/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_core.hpp
+++ b/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_core.hpp
@@ -146,10 +146,20 @@ public:
 
   /**
    * @brief Main inference entry point. Processes one synchronized frame of camera and LiDAR data.
+   *        Converts data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16).
    * @param camera_images Vector of camera images
    * @param lidar_points Vector of LiDAR points
    * @param num_points Number of LiDAR points
    * @return Vector of detected 3D bounding boxes
+   *
+   * @note lidar_points is a flattened 1D vector containing all the raw LiDAR data for a single frame
+   *       - lidar_points.size() equals num_points * config_.num_features.
+   *       - The vector looks like [x1, y1, z1, i1, r1, x2, y2, z2, i2, r2, ...],
+   *         where (x,y,z) are coordinates, i is intensity and r is ring number.
+   * @note Preconditions:
+   *       - initialize() called and returned true; pipeline_ and stream_ are live.
+   *       - updateCalibration() called at least once; pipeline needs camera extrinsics/intrinsics before its first forward pass
+   *         to relate cameras to the LiDAR.
    */
   std::vector<BoundingBox> infer(
     const std::vector<const unsigned char *> & camera_images, const std::vector<float> & lidar_points, int num_points);

--- a/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_core.hpp
+++ b/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_core.hpp
@@ -170,6 +170,9 @@ public:
    * @param camera_instrinsics 3x3 camera intrinsics matrix
    * @param lidar_to_camera 4x4 LiDAR to camera transformation matrix
    * @param img_aug_matrix 4x4 image augmentation matrix
+   *
+   * @note Preconditions:
+   *       - initialize() called and returned true; pipeline_ and stream_ are live.
    */
   void updateCalibration(
     const std::vector<float> & camera_to_lidar,
@@ -183,9 +186,16 @@ public:
    */
   bool isInitialized() const;
 
+  /**
+   * @brief Check if the calibration is initialized
+   * @return true if calibration is initialized, false otherwise
+   */
+  bool hasCalibration() const;
+
 private:
   BEVFusionInputConfig config_;
   bool initialized_ = false;
+  bool has_calibration_ = false;
   cudaStream_t stream_ = nullptr;
   std::shared_ptr<::bevfusion::Core>
     pipeline_;  // Reference to CUDA-BEVFusion pipeline, not wato's BEVFusionCore class.

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -142,24 +142,24 @@ bool BEVFusionCore::initialize()
   return true;
 }
 
-//Convert data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16)
-//preconditions: initialize() called and returned true; pipeline_ and stream_ are live
+// Convert data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16)
+// preconditions: initialize() called and returned true; pipeline_ and stream_ are live
 //               updateCalibration() called at least once; pipeline needs camera extrinsics/intrinsics before its first forward pass to relate cameras to the LiDAR
 std::vector<BoundingBox> BEVFusionCore::infer(
   const std::vector<const unsigned char *> & camera_images, const std::vector<float> & lidar_points, int num_points)
 {
-  if (!initialized_) return {};  //guard check, return empty vector if pipeline is not initialized
+  if (!initialized_) return {};  // guard check, return empty vector if pipeline is not initialized
 
-  //fp16 conversion
+  // fp16 conversion
   std::vector<nvtype::half> lidar_half(
-    lidar_points.size());  //size() - total # of floats in flat array of 5 features per lidar point
+    lidar_points.size());  // size() - total # of floats in flat array of 5 features per lidar point
   for (size_t i = 0; i < lidar_points.size(); ++i) {
     lidar_half[i] = __float2half(lidar_points[i]);
   }
 
   // bevfusion forward pass call
   auto detections =
-    pipeline_->forward(camera_images.data(), lidar_half.data(), num_points, stream_);  //.data() for underlying array
+    pipeline_->forward(camera_images.data(), lidar_half.data(), num_points, stream_);  // .data() for underlying array
 
   // map vendor type to our bounding box type
   std::vector<BoundingBox> result;

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -183,16 +183,9 @@ void BEVFusionCore::updateCalibration(
   const std::vector<float> & lidar_to_camera,
   const std::vector<float> & img_aug_matrix)
 {
-  /**
- * TODO(bevfusion_team)
- * Overview: Feed the current physical positions of the cameras (extrinsics) and lens properties (instrinsics) to
- *           the BEVFusion Core (pipeline_). This is done by calling pipeline_->update() with the appropriate
- *           parameters. Note: Extrinsic and instrinsics are static, so only run this once at startup or when calibration
- *           changes. MUST be called before the first forward() call.
- *
- * Call core_->update(camera2lidar.data(), camera_intrinsics.data(), lidar2image.data(), img_aug_matrix.data(), stream_)
- * and that I think that should be it.
- */
+  if (!initialized_) return;
+  pipeline_->update(
+    camera_to_lidar.data(), camera_intrinsics.data(), lidar_to_camera.data(), img_aug_matrix.data(), stream_);
 }
 
 }  // namespace wato::perception::bevfusion

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -152,15 +152,27 @@ std::vector<BoundingBox> BEVFusionCore::infer(
   }
 
   // Convert LiDAR points to FP16 from any format (FP32, FP16, or INT8)
-  // Note: lidar_points.size() is the total # of floats in the flat array of 5 features per lidar point
-  std::vector<nvtype::half> lidar_half(lidar_points.size());
+  // Notes:
+  // - lidar_points.size() is the total # of floats in the flat array of 5 features per lidar point
+  // - We set lidar_half as a vector of __half and not nvtype::half because __float2half returns __half format.
+  std::vector<__half> lidar_half(lidar_points.size());
   for (size_t i = 0; i < lidar_points.size(); ++i) {
     lidar_half[i] = __float2half(lidar_points[i]);
   }
 
-  // bevfusion forward pass call
-  auto detections =
-    pipeline_->forward(camera_images.data(), lidar_half.data(), num_points, stream_);  // .data() for underlying array
+  // Bevfusion forward pass call
+  // Notes:
+  // - camera_images.data(): gives the array of image pointers. Each pointer points to the start of the data for one camera.
+  //   The `const_cast` is used because the vendor library expects a non-const pointer, even though it doesn't modify the image data.
+  // - lidar_half.data(): gives a pointer to the first element of the vector containing points in __half format.
+  //   The `reinterpret_cast` is used to cast this pointer to `const nvtype::half*`, which is the expected type for the vendor library API.
+  //   Could have also used memcpy to manually copy bits from __half to nvtype::half since they are bitwise identical.
+  // - Use .data() for underlying array
+  auto detections = pipeline_->forward(
+    const_cast<const unsigned char **>(camera_images.data()),
+    reinterpret_cast<const nvtype::half *>(lidar_half.data()),
+    num_points,
+    stream_);
 
   // map vendor type to our bounding box type
   std::vector<BoundingBox> result;

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -142,17 +143,17 @@ bool BEVFusionCore::initialize()
   return true;
 }
 
-// Convert data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16)
-// preconditions: initialize() called and returned true; pipeline_ and stream_ are live
-//               updateCalibration() called at least once; pipeline needs camera extrinsics/intrinsics before its first forward pass to relate cameras to the LiDAR
 std::vector<BoundingBox> BEVFusionCore::infer(
   const std::vector<const unsigned char *> & camera_images, const std::vector<float> & lidar_points, int num_points)
 {
-  if (!initialized_) return {};  // guard check, return empty vector if pipeline is not initialized
+  if (!initialized_) {
+    std::cerr << "Error: BEVFusionCore::infer called before initialization." << std::endl;
+    return {};  // guard check, return empty vector if pipeline is not initialized
+  }
 
-  // fp16 conversion
-  std::vector<nvtype::half> lidar_half(
-    lidar_points.size());  // size() - total # of floats in flat array of 5 features per lidar point
+  // Convert LiDAR points to FP16 from any format (FP32, FP16, or INT8)
+  // Note: lidar_points.size() is the total # of floats in the flat array of 5 features per lidar point
+  std::vector<nvtype::half> lidar_half(lidar_points.size());
   for (size_t i = 0; i < lidar_points.size(); ++i) {
     lidar_half[i] = __float2half(lidar_points[i]);
   }
@@ -183,7 +184,10 @@ void BEVFusionCore::updateCalibration(
   const std::vector<float> & lidar_to_camera,
   const std::vector<float> & img_aug_matrix)
 {
-  if (!initialized_) return;
+  if (!initialized_) {
+    std::cerr << "Error: BEVFusionCore::updateCalibration called before initialization." << std::endl;
+    return;
+  }
   pipeline_->update(
     camera_to_lidar.data(), camera_intrinsics.data(), lidar_to_camera.data(), img_aug_matrix.data(), stream_);
 }

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -45,6 +45,11 @@ bool BEVFusionCore::isInitialized() const
   return initialized_;
 }
 
+bool BEVFusionCore::hasCalibration() const
+{
+  return has_calibration_;
+}
+
 bool BEVFusionCore::initialize()
 {
   // Must load this plugin before create_core() — TRT will fail to deserialize head.bbox.plan without it
@@ -150,6 +155,10 @@ std::vector<BoundingBox> BEVFusionCore::infer(
     std::cerr << "Error: BEVFusionCore::infer called before initialization." << std::endl;
     return {};  // guard check, return empty vector if pipeline is not initialized
   }
+  if (!has_calibration_) {
+    std::cerr << "Error: BEVFusionCore::infer called before calibration was updated." << std::endl;
+    return {};
+  }
 
   // Convert LiDAR points to FP16 from any format (FP32, FP16, or INT8)
   // Notes:
@@ -202,6 +211,7 @@ void BEVFusionCore::updateCalibration(
   }
   pipeline_->update(
     camera_to_lidar.data(), camera_intrinsics.data(), lidar_to_camera.data(), img_aug_matrix.data(), stream_);
+  has_calibration_ = true;
 }
 
 }  // namespace wato::perception::bevfusion

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -142,18 +142,39 @@ bool BEVFusionCore::initialize()
   return true;
 }
 
+//Convert data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16)
+//preconditions: initialize() called and returned true; pipeline_ and stream_ are live
+//               updateCalibration() called at least once; pipeline needs camera extrinsics/intrinsics before its first forward pass to relate cameras to the LiDAR
 std::vector<BoundingBox> BEVFusionCore::infer(
   const std::vector<const unsigned char *> & camera_images, const std::vector<float> & lidar_points, int num_points)
 {
-  /**
- * TODO(bevfusion_team)
- * Overview: Convert data to required format and feed it to GPU pipeline (needs LiDAR data to be FP16)
- *
- * Key steps:
- *   1. Convert the input `lidar_points` (vector of `float`) into a vector of `nvtype::half`.
- *   2. Call `pipeline_->forward(images.data(), lidar_half.data(), num_points, stream_)`.
- *   3. Return the `std::vector<BoundingBox>` result.
- */
+  if (!initialized_) return {};  //guard check, return empty vector if pipeline is not initialized
+
+  //fp16 conversion
+  std::vector<nvtype::half> lidar_half(
+    lidar_points.size());  //size() - total # of floats in flat array of 5 features per lidar point
+  for (size_t i = 0; i < lidar_points.size(); ++i) {
+    lidar_half[i] = __float2half(lidar_points[i]);
+  }
+
+  // bevfusion forward pass call
+  auto detections =
+    pipeline_->forward(camera_images.data(), lidar_half.data(), num_points, stream_);  //.data() for underlying array
+
+  // map vendor type to our bounding box type
+  std::vector<BoundingBox> result;
+  result.reserve(detections.size());
+  for (const auto & d : detections) {
+    BoundingBox box;
+    box.position = {d.position.x, d.position.y, d.position.z};
+    box.size = {d.size.w, d.size.l, d.size.h};
+    box.velocity = {d.velocity.vx, d.velocity.vy};
+    box.z_rotation = d.z_rotation;
+    box.score = d.score;
+    box.id = d.id;
+    result.push_back(box);
+  }
+  return result;
 }
 
 void BEVFusionCore::updateCalibration(

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
@@ -19,6 +19,17 @@
 using wato::perception::bevfusion::BEVFusionCore;
 using wato::perception::bevfusion::BEVFusionInputConfig;
 
+static BEVFusionInputConfig make_test_config()
+{
+  BEVFusionInputConfig config;
+  config.camera_backbone_plan = "/dev/null/camera.backbone.plan";
+  config.camera_vtransform_plan = "/dev/null/camera.vtransform.plan";
+  config.fuser_plan = "/dev/null/fuser.plan";
+  config.head_bbox_plan = "/dev/null/head.bbox.plan";
+  config.lidar_backbone_onnx = "/dev/null/lidar.backbone.onnx";
+  return config;
+}
+
 // =============================================================================
 // TEST 1: Guard flag before initialize()
 // WHY: BEVFusionCore must start in the uninitialized state. Calling infer() or
@@ -28,13 +39,18 @@ using wato::perception::bevfusion::BEVFusionInputConfig;
 // =============================================================================
 TEST_CASE("BEVFusionCore: isInitialized is false after construction", "[core][fast]")
 {
-  BEVFusionInputConfig config;
-  config.camera_backbone_plan = "/dev/null/camera.backbone.plan";
-  config.camera_vtransform_plan = "/dev/null/camera.vtransform.plan";
-  config.fuser_plan = "/dev/null/fuser.plan";
-  config.head_bbox_plan = "/dev/null/head.bbox.plan";
-  config.lidar_backbone_onnx = "/dev/null/lidar.backbone.onnx";
-
-  BEVFusionCore core(config);
+  BEVFusionCore core(make_test_config());
   REQUIRE_FALSE(core.isInitialized());
+}
+
+// =============================================================================
+// TEST 2: infer() guard before initialize()
+// WHY: infer() requires pipeline_ and stream_ to be live. Calling it before
+//      initialize() would dereference a null pipeline_ — undefined behavior.
+//      This verifies the guard returns an empty vector safely, no GPU needed.
+// =============================================================================
+TEST_CASE("BEVFusionCore: infer returns empty vector when not initialized", "[core][fast]")
+{
+  BEVFusionCore core(make_test_config());
+  REQUIRE(core.infer({}, {}, 0).empty());
 }

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
@@ -66,3 +66,21 @@ TEST_CASE("BEVFusionCore: updateCalibration does not crash when not initialized"
   BEVFusionCore core(make_test_config());
   REQUIRE_NOTHROW(core.updateCalibration({}, {}, {}, {}));
 }
+
+// =============================================================================
+// TEST 4: hasCalibration() state tracking
+// WHY: The core must track if calibration matrices have been provided. It should
+//      start false, and if updateCalibration is called before initialization,
+//      it should remain false (since the update fails).
+// =============================================================================
+TEST_CASE("BEVFusionCore: hasCalibration tracks state correctly", "[core][fast]")
+{
+  BEVFusionCore core(make_test_config());
+
+  // 1. Should be false initially
+  REQUIRE_FALSE(core.hasCalibration());
+  // 2. Try to update calibration (this will fail internally because isInitialized() == false)
+  core.updateCalibration({}, {}, {}, {});
+  // 3. Should still be false because the calibration update was rejected
+  REQUIRE_FALSE(core.hasCalibration());
+}

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
@@ -54,3 +54,15 @@ TEST_CASE("BEVFusionCore: infer returns empty vector when not initialized", "[co
   BEVFusionCore core(make_test_config());
   REQUIRE(core.infer({}, {}, 0).empty());
 }
+
+// =============================================================================
+// TEST 3: updateCalibration() guard before initialize()
+// WHY: updateCalibration() calls pipeline_->update(), which requires pipeline_
+//      to be live. Calling it before initialize() would dereference a null
+//      pipeline_. This verifies the guard silently no-ops instead of crashing.
+// =============================================================================
+TEST_CASE("BEVFusionCore: updateCalibration does not crash when not initialized", "[core][fast]")
+{
+  BEVFusionCore core(make_test_config());
+  REQUIRE_NOTHROW(core.updateCalibration({}, {}, {}, {}));
+}


### PR DESCRIPTION
### 📑 Description
Implements `BEVFusionCore::infer()`, which converts incoming LiDAR float data to FP16,
calls `pipeline_->forward()` on the CUDA-BEVFusion pipeline, and maps the vendor
`::bevfusion::head::transbbox::BoundingBox` results to WATO's `BoundingBox` type.
Also refactors `test_bevfusion_core.cpp` to use a shared `make_test_config()` helper
to eliminate repeated setup across test cases.

### 📹 (Optional) Video Demo of Changes
N/A — no runtime output until `updateCalibration()` and `on_configure()` are implemented.

### ✅ Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the "Notes" section

### 🔗 Related Issues / PRs
Follows angie/bevfusion-core-initialize (initialize(), destructor, isInitialized())