### PR TITLE
Implement bevfusion core updateCalibration()

### DIFF
--- a/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_core.cpp
@@ -183,16 +183,9 @@ void BEVFusionCore::updateCalibration(
   const std::vector<float> & lidar_to_camera,
   const std::vector<float> & img_aug_matrix)
 {
-  /**
- * TODO(bevfusion_team)
- * Overview: Feed the current physical positions of the cameras (extrinsics) and lens properties (instrinsics) to
- *           the BEVFusion Core (pipeline_). This is done by calling pipeline_->update() with the appropriate
- *           parameters. Note: Extrinsic and instrinsics are static, so only run this once at startup or when calibration
- *           changes. MUST be called before the first forward() call.
- *
- * Call core_->update(camera2lidar.data(), camera_intrinsics.data(), lidar2image.data(), img_aug_matrix.data(), stream_)
- * and that I think that should be it.
- */
+  if (!initialized_) return;
+  pipeline_->update(
+    camera_to_lidar.data(), camera_intrinsics.data(), lidar_to_camera.data(), img_aug_matrix.data(), stream_);
 }
 
 }  // namespace wato::perception::bevfusion

--- a/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
+++ b/src/perception/bevfusion/bevfusion/test/test_bevfusion_core.cpp
@@ -54,3 +54,15 @@ TEST_CASE("BEVFusionCore: infer returns empty vector when not initialized", "[co
   BEVFusionCore core(make_test_config());
   REQUIRE(core.infer({}, {}, 0).empty());
 }
+
+// =============================================================================
+// TEST 3: updateCalibration() guard before initialize()
+// WHY: updateCalibration() calls pipeline_->update(), which requires pipeline_
+//      to be live. Calling it before initialize() would dereference a null
+//      pipeline_. This verifies the guard silently no-ops instead of crashing.
+// =============================================================================
+TEST_CASE("BEVFusionCore: updateCalibration does not crash when not initialized", "[core][fast]")
+{
+  BEVFusionCore core(make_test_config());
+  REQUIRE_NOTHROW(core.updateCalibration({}, {}, {}, {}));
+}


### PR DESCRIPTION
### 📑 Description
Implements `BEVFusionCore::updateCalibration()`, which feeds camera extrinsic and intrinsic matrices into the CUDA-BEVFusion pipeline via `pipeline_->update()`. Must be called once before the first `infer()` call so the pipeline knows how each camera relates to the LiDAR in 3D space. Also adds a fast unit test verifying the guard silently no-ops when called before `initialize()`.

### 📹 (Optional) Video Demo of Changes

N/A — no runtime output until `on_configure()` and `on_activate()` wire everything together

### ✅ Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the "Notes" section

### 🔗 Related Issues / PRs
Follows angie/bevfusion-core-initialize and angie/bevfusion-core-infer