### PR TITLE
Sample |κ| across the lookahead horizon for the cornering-speed budget

### DIFF
--- a/src/action/ackermann_pure_pursuit/README.md
+++ b/src/action/ackermann_pure_pursuit/README.md
@@ -23,7 +23,7 @@ The pure pursuit node receives a planned trajectory, transforms each waypoint in
 |-------|------|-------------|
 | `/action/ackermann` | `ackermann_msgs/AckermannDriveStamped` | Steering angle and speed command |
 | `/action/is_idle` | `std_msgs/Bool` | `true` when idle or in standby (the disengage monitor does **not** raise this) |
-| `controller_status` | `wato_trajectory_msgs/ControllerStatus` | Per-cycle tracking error, effective lookahead, path curvature, commands, and disengage state/reason |
+| `controller_status` | `wato_trajectory_msgs/ControllerStatus` | Per-cycle tracking error, effective lookahead, path curvature at the steering lookahead, the max \|κ\| sampled across the speed-limit horizon, commands, and disengage state/reason |
 
 Also subscribes to `odom` (`nav_msgs/Odometry`) for the current longitudinal speed used by the adaptive lookahead and speed scheduling.
 
@@ -53,6 +53,7 @@ Parameters are read once in `on_configure`. To change them at runtime, transitio
 | `curvature_lookahead_gain` | double | `2.0` | Shrinks lookahead in curves: `ld_eff = ld / (1 + gain·|κ|)` |
 | `speed_lookahead_distance` | double | `1.0` | Minimum distance ahead used to sample target speed (m) |
 | `speed_lookahead_time` | double | `2.0` | Time-headway for the (decoupled, longer) speed sample horizon (s) |
+| `speed_limit_probe_count` | int | `3` | Number of \|κ\| samples across `[min_lookahead_distance, lookahead_distance]` fed to the curvature-limited speed budget. `1` reproduces the previous single-point behaviour |
 
 **Steering & speed**
 
@@ -129,6 +130,8 @@ where $L$ is the wheelbase, $(x, y)$ is the lookahead point in `rear_axle_frame`
 ### Speed control
 
 Target speed is the minimum of the path's requested speed (sampled at a decoupled, speed-scaled horizon `max(speed_lookahead_distance, speed_lookahead_time·speed)`) and the curvature-limited speed `sqrt(max_lateral_accel / |κ|)` — so the vehicle slows *before* a curve within a lateral-acceleration budget rather than reacting to steering after the fact. The result is clamped to `[min_speed, max_speed]` (or `0` if the path commands a stop) and then accel/decel slew-limited by `max_accel` / `max_decel`.
+
+The `|κ|` used in the cornering-speed budget is the maximum of two estimates: the curvature at the steering lookahead point, and the maximum `|κ|` sampled at `speed_limit_probe_count` distances spanning `[min_lookahead_distance, lookahead_distance]`. Densifying the samples inside the existing horizon catches a sharp section that the single steering lookahead can straddle (e.g. lookahead falling just before a curve entry), so `v_curve` is bounded by whatever the sharpest part of the visible path demands rather than by the incidental point the steering law happened to pick. Setting `speed_limit_probe_count: 1` reproduces the previous single-point behaviour exactly. Steering geometry is untouched by this change.
 
 ### Optional low-speed blend
 

--- a/src/action/ackermann_pure_pursuit/config/params.yaml
+++ b/src/action/ackermann_pure_pursuit/config/params.yaml
@@ -21,6 +21,7 @@ action:
       curvature_est_arc: 1.5            # half-window arc length for curvature estimation (m)
       speed_lookahead_distance: 1.0     # minimum distance ahead used to sample target speed (m)
       speed_lookahead_time: 2.0         # time-headway for the speed sample horizon (s)
+      speed_limit_probe_count: 3        # samples across [min_lookahead_distance, lookahead_distance] fed to the curvature-limited speed budget (1 = current behaviour)
 
       # --- Steering ---
       steering_angle_gain: 1.0

--- a/src/action/ackermann_pure_pursuit/include/ackermann_pure_pursuit/pure_pursuit_math.hpp
+++ b/src/action/ackermann_pure_pursuit/include/ackermann_pure_pursuit/pure_pursuit_math.hpp
@@ -273,6 +273,44 @@ inline double pursuitCurvature(const Vec2 & lookahead)
   return 2.0 * lookahead.y / ld_sq;
 }
 
+// Maximum |kappa| sampled along the forward path over `probe_count` distances
+// spanning [min_ld, max_ld]. Densifying what we look at inside the existing
+// horizon lets the curvature-limited speed budget catch a sharp section that a
+// single-lookahead probe can straddle (e.g. lookahead falling just before a
+// curve entry). Steering geometry is untouched; this is a speed-budget input.
+// Returns 0 when no forward point is reachable or fewer than one probe is
+// requested.
+inline double maxAbsCurvatureOverHorizon(
+  const std::vector<Vec2> & path,
+  double min_ld,
+  double max_ld,
+  std::size_t probe_count,
+  double curvature_est_arc,
+  std::size_t start_idx = 0)
+{
+  if (probe_count == 0 || path.size() < 3) {
+    return 0.0;
+  }
+  double lo = std::min(min_ld, max_ld);
+  double hi = std::max(min_ld, max_ld);
+  double kappa_max = 0.0;
+  for (std::size_t i = 0; i < probe_count; ++i) {
+    double ld = hi;
+    if (probe_count > 1) {
+      ld = lo + (hi - lo) * static_cast<double>(i) / static_cast<double>(probe_count - 1);
+    }
+    LookaheadResult r = findLookaheadPoint(path, ld, min_ld, start_idx);
+    if (!r.found) {
+      continue;
+    }
+    double k = std::abs(curvatureByArc(path, r.segment_idx, curvature_est_arc));
+    if (k > kappa_max) {
+      kappa_max = k;
+    }
+  }
+  return kappa_max;
+}
+
 // --------------------------------------------------------------------------
 // Speed / command shaping
 // --------------------------------------------------------------------------

--- a/src/action/ackermann_pure_pursuit/include/ackermann_pure_pursuit/pure_pursuit_node.hpp
+++ b/src/action/ackermann_pure_pursuit/include/ackermann_pure_pursuit/pure_pursuit_node.hpp
@@ -87,6 +87,8 @@ private:
   double curvature_est_arc_;  // half-window arc length for curvature estimation (m)
   double speed_lookahead_distance_;  // minimum distance ahead used to sample target speed (m)
   double speed_lookahead_time_;  // time-headway for the speed sample horizon (s)
+  int
+    speed_limit_probe_count_;  // samples over [min_lookahead_distance, lookahead_distance] feeding v_curve; 1 = current behaviour
 
   // Parameters — steering
   double steering_angle_gain_;

--- a/src/action/ackermann_pure_pursuit/src/pure_pursuit_node.cpp
+++ b/src/action/ackermann_pure_pursuit/src/pure_pursuit_node.cpp
@@ -53,6 +53,7 @@ PurePursuitNode::PurePursuitNode(const rclcpp::NodeOptions & options)
   declare_parameter("curvature_est_arc", 1.5);
   declare_parameter("speed_lookahead_distance", 1.0);
   declare_parameter("speed_lookahead_time", 2.0);
+  declare_parameter("speed_limit_probe_count", 3);
 
   // Steering
   declare_parameter("steering_angle_gain", 1.0);
@@ -139,6 +140,7 @@ void PurePursuitNode::loadParameters()
   curvature_est_arc_ = get_parameter("curvature_est_arc").as_double();
   speed_lookahead_distance_ = get_parameter("speed_lookahead_distance").as_double();
   speed_lookahead_time_ = get_parameter("speed_lookahead_time").as_double();
+  speed_limit_probe_count_ = static_cast<int>(get_parameter("speed_limit_probe_count").as_int());
 
   steering_angle_gain_ = get_parameter("steering_angle_gain").as_double();
   max_steering_angle_ = get_parameter("max_steering_angle").as_double();
@@ -403,6 +405,7 @@ void PurePursuitNode::controlCallback()
   // --- Desired steering / speed for this cycle ---
   double desired_steering = 0.0;
   double desired_speed = 0.0;
+  double kappa_for_speed = 0.0;  // curvature fed to the v_curve budget (may exceed kappa_ahead)
   bool over = false;
   std::string reason = "ok";
 
@@ -434,7 +437,24 @@ void PurePursuitNode::controlCallback()
     double path_speed = math::minSpeedWithinHorizon(path, speeds, speed_horizon, max_speed_, search_start);
 
     // Curvature-limited speed (Phase 3a): keep lateral accel within budget.
-    double v_curve = math::curvatureLimitedSpeed(max_lateral_accel_, kappa_ahead, max_speed_);
+    // Sample |kappa| at several distances across [min_lookahead, lookahead] and
+    // take the max, so a sharp section that the single steering-lookahead point
+    // straddles (e.g. lookahead falling just before a curve entry) still bounds
+    // the speed budget. probe_count = 1 falls back to the single-point behaviour.
+    kappa_for_speed = kappa_ahead;
+    if (speed_limit_probe_count_ > 1) {
+      double kappa_horizon = math::maxAbsCurvatureOverHorizon(
+        path,
+        min_lookahead_distance_,
+        lookahead_distance_,
+        static_cast<std::size_t>(speed_limit_probe_count_),
+        curvature_est_arc_,
+        search_start);
+      if (kappa_horizon > std::abs(kappa_for_speed)) {
+        kappa_for_speed = kappa_horizon;
+      }
+    }
+    double v_curve = math::curvatureLimitedSpeed(max_lateral_accel_, kappa_for_speed, max_speed_);
     if (path_speed <= 0.0) {
       desired_speed = 0.0;  // path commands a stop
     } else {
@@ -486,6 +506,7 @@ void PurePursuitNode::controlCallback()
   status.heading_error = err.valid ? err.heading : 0.0;
   status.lookahead_distance = ld_eff;
   status.path_curvature = kappa_ahead;
+  status.speed_limit_curvature = kappa_for_speed;
   status.commanded_speed = speed;
   status.commanded_steering = invert_steering_ ? -steering : steering;
   status.disengaged = disengaged;

--- a/src/action/ackermann_pure_pursuit/test/pure_pursuit_math_test.cpp
+++ b/src/action/ackermann_pure_pursuit/test/pure_pursuit_math_test.cpp
@@ -212,3 +212,69 @@ TEST_CASE("pursuit curvature matches the geometric formula", "[lookahead]")
   CHECK(ppm::pursuitCurvature({3.0, 0.0}) == Approx(0.0));
   CHECK(ppm::pursuitCurvature({2.0, 2.0}) == Approx(0.5));  // 2*y/(x^2+y^2) = 4/8
 }
+
+TEST_CASE("horizon curvature scan catches a sharp section a single probe skips", "[speed_budget]")
+{
+  // Path: straight to x=3, then a sharp U-shaped arc of R = 0.5 (|kappa| = 2),
+  // then continues straight at y=1. Probe range [2, 5]:
+  //   - N=1 probes only at ld=5, which lands on the straight AFTER the arc -> kappa=0.
+  //   - N=3 probes at {2, 3.5, 5}: the 3.5 probe lands on the arc -> kappa >> 0.
+  // This is the exact "single lookahead straddles the curve" case the change is
+  // supposed to fix.
+  std::vector<Vec2> path;
+  for (double x = 0.0; x <= 3.0; x += 0.5) {
+    path.push_back({x, 0.0});
+  }
+  const double cx = 3.0, cy = 0.5, R = 0.5;
+  for (double theta = -M_PI / 2.0; theta <= M_PI / 2.0; theta += 0.1) {
+    path.push_back({cx + R * std::cos(theta), cy + R * std::sin(theta)});
+  }
+  for (double x = 3.0; x <= 8.0; x += 0.5) {
+    path.push_back({x, 1.0});
+  }
+
+  const double min_ld = 2.0;
+  const double max_ld = 5.0;
+  const double arc = 1.0;
+
+  double kappa_single = ppm::maxAbsCurvatureOverHorizon(path, min_ld, max_ld, 1, arc);
+  double kappa_multi = ppm::maxAbsCurvatureOverHorizon(path, min_ld, max_ld, 3, arc);
+
+  CHECK(kappa_single == Approx(0.0));  // single probe misses the arc
+  CHECK(kappa_multi > 1.0);  // multi-probe catches it (true |kappa| ~ 2/R = 2)
+}
+
+TEST_CASE("horizon curvature scan is a no-op on straight paths", "[speed_budget]")
+{
+  std::vector<Vec2> straight;
+  for (double x = 0.0; x <= 10.0; x += 0.5) {
+    straight.push_back({x, 0.0});
+  }
+  double k = ppm::maxAbsCurvatureOverHorizon(straight, 2.0, 5.0, 5, 1.0);
+  CHECK(k == Approx(0.0));
+}
+
+TEST_CASE("horizon curvature scan with probe_count=1 uses the max distance only", "[speed_budget]")
+{
+  // Straight then bend at ~5 m: a single probe at max_ld should sample the bend,
+  // while a probe placed only at min_ld would miss it. Confirms our N=1 semantics.
+  std::vector<Vec2> path;
+  for (double x = 0.0; x <= 4.5; x += 0.5) {
+    path.push_back({x, 0.0});
+  }
+  const double cx = 4.5, cy = 2.0, R = 2.0;
+  for (double theta = -M_PI / 2.0; theta <= 0.0; theta += 0.1) {
+    path.push_back({cx + R * std::cos(theta), cy + R * std::sin(theta)});
+  }
+  double k = ppm::maxAbsCurvatureOverHorizon(path, 2.0, 5.0, 1, 1.0);
+  CHECK(k > 0.0);  // saw the bend
+}
+
+TEST_CASE("horizon curvature scan tolerates degenerate inputs", "[speed_budget]")
+{
+  // Empty path -> 0
+  CHECK(ppm::maxAbsCurvatureOverHorizon({}, 2.0, 5.0, 3, 1.0) == Approx(0.0));
+  // Zero probes -> 0
+  std::vector<Vec2> path{{0, 0}, {1, 0}, {2, 0}};
+  CHECK(ppm::maxAbsCurvatureOverHorizon(path, 2.0, 5.0, 0, 1.0) == Approx(0.0));
+}

--- a/src/action/wato_trajectory_msgs/msg/ControllerStatus.msg
+++ b/src/action/wato_trajectory_msgs/msg/ControllerStatus.msg
@@ -9,8 +9,9 @@ float64 cross_track_error    # signed lateral distance to nearest path segment (
 float64 heading_error        # signed angle between vehicle heading and path tangent (rad)
 
 # --- Controller internals for this cycle ---
-float64 lookahead_distance   # effective lookahead distance used (m)
-float64 path_curvature       # estimated path curvature ahead (1/m)
+float64 lookahead_distance     # effective lookahead distance used (m)
+float64 path_curvature         # estimated path curvature at the steering lookahead (1/m)
+float64 speed_limit_curvature  # max |kappa| sampled across [min_lookahead, lookahead] and fed to v_curve (1/m)
 float64 commanded_speed      # speed command sent (m/s)
 float64 commanded_steering   # steering command sent (rad)
 


### PR DESCRIPTION
### 📑  Description

Extend the curvature-limited speed budget to take `max |κ|` across several probe distances spanning `[min_lookahead_distance, lookahead_distance]`, instead of using the single κ estimated at the steering lookahead.

The current adaptive controller estimates κ once, at the steering lookahead point, and feeds it to `v_curve = sqrt(max_lateral_accel / |κ|)`. If a sharp path section falls *between* the vehicle and the steering lookahead (e.g. the lookahead lands just past a curve entry, on the outbound straight), the single-point estimate returns a near-zero κ, `v_curve` stays at `max_speed`, and the vehicle enters the curve without having decelerated. Densifying the samples inside the existing horizon lets the speed budget catch these sections.

This is the first step toward the multi-look-ahead pure pursuit work in issue #505. Steering geometry is untouched by this PR.

### 🔗  Related Issues / PRs

Related to #505 (multi-look-ahead pure pursuit); this PR lands the speed-budget improvement independently, so it can be evaluated on its own before the MLPP steering blend work.

### 📝  Notes for reviewers

**Design decisions worth flagging:**

1. **N probes calling `findLookaheadPoint` N times, not a single-sweep `findLookaheadPoints`.** The issue text explicitly suggests a single forward sweep, and that's what PR 2 (MLPP steering blend) will need. For this PR, N is small (default 3), paths are ~200 points, and the cycle rate is 20 Hz; the perf difference is submicrosecond and unmeasurable. Introducing a `findLookaheadPoints` API here means committing to a signature before PR 2 knows exactly what it wants back (steering blending needs the actual `(x, y)` point per probe, not just the segment index for a κ estimate). Deferring the single-sweep helper to PR 2 lets that API get designed once, in the PR where it actually matters.

2. **`if (speed_limit_probe_count_ > 1)` guard around the new logic.** Setting `speed_limit_probe_count: 1` in `config/params.yaml` skips the new branch entirely and reproduces the previous single-point behaviour exactly. This is the safety fallback if the new default (`3`) causes any unexpected behaviour on the test track: it can be reverted by config, no code change needed.

3. **`std::max(kappa_ahead, kappa_horizon)` monotonicity.** The new `kappa_for_speed` value can only ever *raise* κ, never lower it, so the cornering-speed budget is provably at least as conservative as before. On straight paths (all probes return κ = 0), the new value equals the old value; there's no way for this change to command a *higher* speed in any scenario.

4. **New `ControllerStatus.speed_limit_curvature` field.** Publishes the κ actually used for `v_curve` alongside the existing `path_curvature` (which still reflects the κ at the steering lookahead). If the two diverge in a bag, that's the visual signal that the horizon scan just prevented a corner-cutting overspeed.

**Testing:**

- `colcon build --packages-up-to ackermann_pure_pursuit` — clean
- `colcon test --packages-select ackermann_pure_pursuit` — 56/56 passing, including 4 new tests in `pure_pursuit_math_test.cpp` covering the win case, the no-op-on-straights case, the N=1 compat case, and degenerate inputs.
- `pre-commit run --all-files` — all hooks green

No CARLA / sim validation for this PR; the change is small, provably conservative by inspection (per point 3 above), and its correctness is captured in the unit tests. Sim validation will be part of the MLPP steering-blend PR where the algorithmic change is bigger.

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the "Notes" section (none; behaviour with `speed_limit_probe_count: 1` is bit-identical to before)