### PR TITLE
Implements cleanup/deactivate/shutdown functions for bevfusion node

### DIFF
--- a/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
+++ b/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
@@ -230,6 +230,9 @@ private:
   std::atomic<uint64_t> total_processed_{0};
   std::atomic<double> total_processing_time_ms_{0.0};
   std::atomic<double> last_processing_time_ms_{0.0};
+  std::atomic<uint64_t> multi_image_msg_count_{0};
+  std::atomic<uint64_t> lidar_msg_count_{0};
+  std::atomic<uint64_t> synced_msg_count_{0};
   std::chrono::steady_clock::time_point last_stats_log_time_;
   static constexpr std::chrono::seconds kStatsLogInterval{30};
 

--- a/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
+++ b/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
@@ -267,7 +267,7 @@ private:
   std::chrono::steady_clock::time_point last_stats_log_time_;
   static constexpr std::chrono::seconds kStatsLogInterval{30};
 
-    // Statistics
+  // Statistics
   std::atomic<uint64_t> multi_image_msg_count_{0};
   std::atomic<uint64_t> lidar_msg_count_{0};
   std::atomic<uint64_t> synced_msg_count_{0};

--- a/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
+++ b/src/perception/bevfusion/bevfusion/include/bevfusion/bevfusion_node.hpp
@@ -261,9 +261,6 @@ private:
   std::atomic<uint64_t> total_processed_{0};
   std::atomic<double> total_processing_time_ms_{0.0};
   std::atomic<double> last_processing_time_ms_{0.0};
-  std::atomic<uint64_t> multi_image_msg_count_{0};
-  std::atomic<uint64_t> lidar_msg_count_{0};
-  std::atomic<uint64_t> synced_msg_count_{0};
   std::chrono::steady_clock::time_point last_stats_log_time_;
   static constexpr std::chrono::seconds kStatsLogInterval{30};
 

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -480,7 +480,19 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BEVFus
 {
   RCLCPP_INFO(this->get_logger(), "Deactivating BEVFusion node");
 
-  // TOOD
+  if (detection_pub_) {
+    detection_pub_->on_deactivate();
+  }
+  if (marker_pub_) {
+    marker_pub_->on_deactivate();
+  }
+
+  sync_.reset();
+  multi_image_sub_.reset();
+  lidar_sub_.reset();
+  multi_camera_info_sub_.reset();
+  calibration_initialized_ = false;
+  camera_info_received_ = false;
 
   RCLCPP_INFO(this->get_logger(), "=============================================");
   RCLCPP_INFO(this->get_logger(), "Node deactivated");
@@ -492,10 +504,19 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BEVFus
 {
   RCLCPP_INFO(this->get_logger(), "Cleaning up BEVFusion node");
 
-  // TODO(bevfusion_team)
+  sync_.reset();
+  multi_image_sub_.reset();
+  lidar_sub_.reset();
+  multi_camera_info_sub_.reset();
+  cached_multi_camera_info_.reset();
 
   RCLCPP_INFO(this->get_logger(), "Cleaning up publishers...");
-  // TODO(bevfusion_team)
+  detection_pub_.reset();
+  marker_pub_.reset();
+  pub_diagnostic_.reset();
+  diagnostic_updater_.reset();
+  tf_listener_.reset();
+  tf_buffer_.reset();
   core_.reset();
 
   RCLCPP_INFO(this->get_logger(), "Node cleaned up");
@@ -520,13 +541,22 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BEVFus
   RCLCPP_INFO(this->get_logger(), "  - Total processing time: %.3f ms", total_time);
   RCLCPP_INFO(this->get_logger(), "  - Average processing time: %.3f ms", avg_time);
   RCLCPP_INFO(this->get_logger(), "Message statistics:");
-  // TODO(bevfusion_team)
+  // TODO(bevfusion_team): log multi_image_msg_count_, lidar_msg_count_, synced_msg_count_ once syncedCallback is implemented
 
   RCLCPP_INFO(this->get_logger(), "Resetting all resources...");
 
-  core_.reset();
+  sync_.reset();
+  multi_image_sub_.reset();
+  lidar_sub_.reset();
+  multi_camera_info_sub_.reset();
+  cached_multi_camera_info_.reset();
+  detection_pub_.reset();
+  marker_pub_.reset();
   pub_diagnostic_.reset();
   diagnostic_updater_.reset();
+  tf_listener_.reset();
+  tf_buffer_.reset();
+  core_.reset();
 
   total_processed_ = 0;
   total_processing_time_ms_ = 0.0;

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -38,11 +38,11 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <vision_msgs/msg/detection3_d_array.hpp>
 #include <visualization_msgs/msg/image_marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include "bevfusion/bevfusion_core.hpp"
 
@@ -173,22 +173,19 @@ void BEVFusionNode::syncedCallback(
 
   if (!core_ || !core_->initialize()) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000,
-      "[SYNC] BEVFusion Core not created or initialized; skipping");
+      this->get_logger(), *this->get_clock(), 5000, "[SYNC] BEVFusion Core not created or initialized; skipping");
     return;
   }
 
   if (!multi_image_msg || multi_image_msg->images.empty()) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000,
-      "[SYNC] MultiImage message is null or empty; skipping");
+      this->get_logger(), *this->get_clock(), 5000, "[SYNC] MultiImage message is null or empty; skipping");
     return;
   }
 
   if (!lidar_msg || lidar_msg->data.empty()) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000,
-      "[SYNC] LiDAR point cloud message is null or empty; skipping");
+      this->get_logger(), *this->get_clock(), 5000, "[SYNC] LiDAR point cloud message is null or empty; skipping");
     return;
   }
 
@@ -204,11 +201,7 @@ void BEVFusionNode::syncedCallback(
     cv::Mat bgr = decompressImage(multi_image_msg->images[i]);
     if (bgr.empty()) {
       RCLCPP_WARN_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(),
-        5000,
-        "Failed to decompress image for frame_id '%s'",
-        frame_id.c_str());
+        this->get_logger(), *this->get_clock(), 5000, "Failed to decompress image for frame_id '%s'", frame_id.c_str());
       return;  // Skip this callback if any image fails to decompress
     }
 
@@ -267,7 +260,6 @@ void BEVFusionNode::computeCalibrationMatrices()
    * 4. Call core_->updateCalibration(camera_to_lidar, camera_intrinsics, lidar_to_camera, img_aug_matrix).
    * 5. Set calibration_initialized_ = true.
    */
-
 }
 
 visualization_msgs::msg::Marker BEVFusionNode::toMarker(
@@ -277,7 +269,7 @@ visualization_msgs::msg::Marker BEVFusionNode::toMarker(
 
   marker.type = visualization_msgs::msg::Marker::CUBE;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.pose.orientation.w = 1.0; // default valid quaternion if no rotation set
+  marker.pose.orientation.w = 1.0;  // default valid quaternion if no rotation set
   marker.pose.position.x = bbox.position.x;
   marker.pose.position.y = bbox.position.y;
   marker.pose.position.z = bbox.position.z;
@@ -323,7 +315,8 @@ visualization_msgs::msg::Marker BEVFusionNode::toMarker(
   return marker;
 }
 
-vision_msgs::msg::Detection3D BEVFusionNode::toDetection3D(const BoundingBox & bbox, const std_msgs::msg::Header & header) const
+vision_msgs::msg::Detection3D BEVFusionNode::toDetection3D(
+  const BoundingBox & bbox, const std_msgs::msg::Header & header) const
 {
   vision_msgs::msg::Detection3D detection;
 
@@ -337,12 +330,12 @@ vision_msgs::msg::Detection3D BEVFusionNode::toDetection3D(const BoundingBox & b
   detection.bbox.center.orientation.x = q.x();
   detection.bbox.center.orientation.y = q.y();
   detection.bbox.center.orientation.z = q.z();
-  detection.bbox.center.orientation.w = q.w();  
+  detection.bbox.center.orientation.w = q.w();
 
   detection.bbox.size.x = bbox.size.l;
   detection.bbox.size.y = bbox.size.w;
   detection.bbox.size.z = bbox.size.h;
-  //(check axis convention — nuScenes uses l=forward, w=lateral, h=vertical)
+  // (check axis convention — nuScenes uses l=forward, w=lateral, h=vertical)
 
   vision_msgs::msg::ObjectHypothesisWithPose hyp;
   hyp.hypothesis.class_id = std::to_string(bbox.id);

--- a/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
+++ b/src/perception/bevfusion/bevfusion/src/bevfusion_node.cpp
@@ -164,9 +164,9 @@ void BEVFusionNode::syncedCallback(
    * 5. Publish
    */
 
-  // multi_image_msg_count_++;
-  // lidar_msg_count_++;
-  // synced_msg_count_++;
+  multi_image_msg_count_++;
+  lidar_msg_count_++;
+  synced_msg_count_++;
 
   if (!core_) {
     RCLCPP_WARN(this->get_logger(), "[SYNC] Core not initialized; skipping");
@@ -541,7 +541,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BEVFus
   RCLCPP_INFO(this->get_logger(), "  - Total processing time: %.3f ms", total_time);
   RCLCPP_INFO(this->get_logger(), "  - Average processing time: %.3f ms", avg_time);
   RCLCPP_INFO(this->get_logger(), "Message statistics:");
-  // TODO(bevfusion_team): log multi_image_msg_count_, lidar_msg_count_, synced_msg_count_ once syncedCallback is implemented
+  RCLCPP_INFO(this->get_logger(), "  - MultiImage messages received: %lu", multi_image_msg_count_.load());
+  RCLCPP_INFO(this->get_logger(), "  - LiDAR messages received: %lu", lidar_msg_count_.load());
+  RCLCPP_INFO(this->get_logger(), "  - Synchronized callbacks: %lu", synced_msg_count_.load());
 
   RCLCPP_INFO(this->get_logger(), "Resetting all resources...");
 
@@ -561,6 +563,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BEVFus
   total_processed_ = 0;
   total_processing_time_ms_ = 0.0;
   last_processing_time_ms_ = 0.0;
+  multi_image_msg_count_ = 0;
+  lidar_msg_count_ = 0;
+  synced_msg_count_ = 0;
 
   RCLCPP_INFO(this->get_logger(), "Node shut down");
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;


### PR DESCRIPTION
### 📑 Description
Implements `on_deactivate`, `on_cleanup`, and `on_shutdown` for `BEVFusionNode`, following the same pattern as `AttributeAssignerNode`. Each method tears down the appropriate resources (subscribers, sync, publishers, diagnostics, TF, core) in the correct order for the lifecycle state being exited.
 Also declares and wires up `multi_image_msg_count_`, `lidar_msg_count_`, and `synced_msg_count_` counters so
`on_shutdown` can log full message statistics.


### 📹 (Optional) Video Demo of Changes
N/A

### ✅ Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the "Notes" section

### 🔗 Related Issues / PRs
N/A