### PR TITLE
Add arg to disable live cameras

### DIFF
--- a/src/perception/perception_bringup/docs/camera_bringup.md
+++ b/src/perception/perception_bringup/docs/camera_bringup.md
@@ -7,6 +7,12 @@ container. They are launched as part of the perception stack:
 ros2 launch perception_bringup perception.launch.yaml
 ```
 
+When testing not directly on the car (e.g. with a rosbag), disable the live cameras as follows:
+
+```sh
+ros2 launch perception_bringup perception.launch.yaml live_cameras:=false
+```
+
 To load the cameras into an existing component container on their own (e.g. for
 debugging or bag recording), use the camera launch directly:
 

--- a/src/perception/perception_bringup/launch/perception.launch.yaml
+++ b/src/perception/perception_bringup/launch/perception.launch.yaml
@@ -23,6 +23,11 @@ launch:
       default: "$(find-pkg-share perception_bringup)/config/hikrobot_camera_config.yaml"
       description: "Hikrobot cameras configuration file"
 
+  - arg:
+      name: live_cameras
+      default: "true"
+      description: "Launch physical camera drivers (set to false when using a rosbag or simulator)"
+
   # ===========================================================================
   # Single component container: cameras, camera_sync, deep object detection, tracking, patchwork++
   # ===========================================================================
@@ -56,6 +61,7 @@ launch:
 
   # Load all 12 camera pipelines into the shared container
   - include:
+      if: "$(var live_cameras)"
       file: "$(find-pkg-share perception_bringup)/launch/all_cameras_composed.yaml"
       arg:
         - name: "container_name"


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the checklist below so we can review your PR faster.
-->

### 📑  Description
<!-- A brief summary of the change. Why is it needed? -->
Launching the perception_bringup with perception.launch.yaml use to fail as the camera drivers don't exist anywhere except when on the car directly. This PR adds a flag preventing loading in physical cameras.

### 📹  (Optional) Video Demo of Changes
<!-- Upload a video demo of your PR! Helps with getting your changes pushed. -->

### ✅  Checklist
- [x] My code builds and runs locally without warnings
- [x] I added/updated tests if needed
- [x] I updated documentation / comments
- [x] I listed any breaking changes in the “Notes” section

### 🔗  Related Issues / PRs
Fixes #123
Depends on #456

### 📝  Notes for reviewers
<!-- Special deployment steps, risks, or anything you’d like a reviewer to know. -->
